### PR TITLE
fix: set the default query params based on configuration

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -59,6 +59,7 @@ sap.ui.define([
 	 *            (oResource.meta.profile[0]) at the requested resource
 	 * @param {string} [mParameters.defaultSubmitMode] The default SubmitMode for all bindings which are associated with this model
 	 * @param {string} [mParameters.defaultFullUrlType='uuid'] The default FullUrlType if the default submit mode is either batch or transaction
+	 * @param {array}  [mParameters.defaultQueryParameters=[]] The default query parameters to be passed to for all GET requests if there is no specific binding info. It should be of type key:value pairs in the array E.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {string} [mParameters.x-csrf-token=true] The model handles the csrf token between the browser and the FHIR server
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
@@ -82,7 +83,8 @@ sap.ui.define([
 			this.sDefaultOperationMode = OperationMode.Server;
 			this.sBaseProfileUrl = mParameters && mParameters.baseProfileUrl ? mParameters.baseProfileUrl : "http://hl7.org/fhir/StructureDefinition/";
 			this._buildGroupProperties(mParameters);
-			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer);
+			this.aDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Array ? mParameters.defaultQueryParameters : [];
+			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.aDefaultQueryParameters);
 			this.sDefaultSubmitMode = (mParameters && mParameters.defaultSubmitMode) ? mParameters.defaultSubmitMode : SubmitMode.Direct;
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";
 			this.oDefaultUri = this.sDefaultFullUrlType === "url" ? new Url() : new Uuid();

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -59,7 +59,7 @@ sap.ui.define([
 	 *            (oResource.meta.profile[0]) at the requested resource
 	 * @param {string} [mParameters.defaultSubmitMode] The default SubmitMode for all bindings which are associated with this model
 	 * @param {string} [mParameters.defaultFullUrlType='uuid'] The default FullUrlType if the default submit mode is either batch or transaction
-	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed as part of GET ALL requests and that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed on resource type specific requests and not resource instance specific request (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {string} [mParameters.x-csrf-token=true] The model handles the csrf token between the browser and the FHIR server
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -83,8 +83,8 @@ sap.ui.define([
 			this.sDefaultOperationMode = OperationMode.Server;
 			this.sBaseProfileUrl = mParameters && mParameters.baseProfileUrl ? mParameters.baseProfileUrl : "http://hl7.org/fhir/StructureDefinition/";
 			this._buildGroupProperties(mParameters);
-			this.aDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Object ? mParameters.defaultQueryParameters : {};
-			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.aDefaultQueryParameters);
+			this.oDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Object ? mParameters.defaultQueryParameters : {};
+			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.oDefaultQueryParameters);
 			this.sDefaultSubmitMode = (mParameters && mParameters.defaultSubmitMode) ? mParameters.defaultSubmitMode : SubmitMode.Direct;
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";
 			this.oDefaultUri = this.sDefaultFullUrlType === "url" ? new Url() : new Uuid();

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -59,7 +59,7 @@ sap.ui.define([
 	 *            (oResource.meta.profile[0]) at the requested resource
 	 * @param {string} [mParameters.defaultSubmitMode] The default SubmitMode for all bindings which are associated with this model
 	 * @param {string} [mParameters.defaultFullUrlType='uuid'] The default FullUrlType if the default submit mode is either batch or transaction
-	 * @param {array}  [mParameters.defaultQueryParameters=[]] The default query parameters to be passed to for all GET requests if there is no specific binding info. It should be of type key:value pairs in the array E.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object}  [mParameters.defaultQueryParameters={}] The default query parameters to be passed to for GET ALL requests that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {string} [mParameters.x-csrf-token=true] The model handles the csrf token between the browser and the FHIR server
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
@@ -83,7 +83,7 @@ sap.ui.define([
 			this.sDefaultOperationMode = OperationMode.Server;
 			this.sBaseProfileUrl = mParameters && mParameters.baseProfileUrl ? mParameters.baseProfileUrl : "http://hl7.org/fhir/StructureDefinition/";
 			this._buildGroupProperties(mParameters);
-			this.aDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Array ? mParameters.defaultQueryParameters : [];
+			this.aDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Object ? mParameters.defaultQueryParameters : {};
 			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.aDefaultQueryParameters);
 			this.sDefaultSubmitMode = (mParameters && mParameters.defaultSubmitMode) ? mParameters.defaultSubmitMode : SubmitMode.Direct;
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -59,7 +59,7 @@ sap.ui.define([
 	 *            (oResource.meta.profile[0]) at the requested resource
 	 * @param {string} [mParameters.defaultSubmitMode] The default SubmitMode for all bindings which are associated with this model
 	 * @param {string} [mParameters.defaultFullUrlType='uuid'] The default FullUrlType if the default submit mode is either batch or transaction
-	 * @param {object}  [mParameters.defaultQueryParameters={}] The default query parameters to be passed to for GET ALL requests that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed as part of GET ALL requests and that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {string} [mParameters.x-csrf-token=true] The model handles the csrf token between the browser and the FHIR server
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -59,7 +59,7 @@ sap.ui.define([
 	 *            (oResource.meta.profile[0]) at the requested resource
 	 * @param {string} [mParameters.defaultSubmitMode] The default SubmitMode for all bindings which are associated with this model
 	 * @param {string} [mParameters.defaultFullUrlType='uuid'] The default FullUrlType if the default submit mode is either batch or transaction
-	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed on resource type specific requests and not resource instance specific request (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed on resource type specific requests and not resource instance specific requests (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {string} [mParameters.x-csrf-token=true] The model handles the csrf token between the browser and the FHIR server
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -27,7 +27,7 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {boolean} bCSRF If the FHIR service supports the csrf token
 	 * @param {string} sPrefer In which kind the FHIR service shall return the responses described here https://www.hl7.org/fhir/http.html#2.21.0.5.2
-	 * @param {object} oDefaultQueryParams The default query parameters to be passed to for GET ALL requests that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} oDefaultQueryParams The default query parameters to be passed as part of GET ALL requests and that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @alias sap.fhir.model.r4.lib.FHIRRequestor
 	 * @author SAP SE
 	 * @constructs {FHIRRequestor} Provides the implementation of the FHIR Requestor to send and retrieve content from a FHIR server

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -27,7 +27,7 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {boolean} bCSRF If the FHIR service supports the csrf token
 	 * @param {string} sPrefer In which kind the FHIR service shall return the responses described here https://www.hl7.org/fhir/http.html#2.21.0.5.2
-	 * @param {object} oDefaultQueryParams The default query parameters to be passed on resource type specific requests and not resource instance specific request (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} oDefaultQueryParams The default query parameters to be passed on resource type specific requests and not resource instance specific requests (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @alias sap.fhir.model.r4.lib.FHIRRequestor
 	 * @author SAP SE
 	 * @constructs {FHIRRequestor} Provides the implementation of the FHIR Requestor to send and retrieve content from a FHIR server

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -423,12 +423,12 @@ sap.ui.define([
 			return "";
 		}
 
-		if (!mParameters._format || !this._isFormatSupported(mParameters._format)) {
-			mParameters._format = "json";
-		}
-
 		if (!oBindingInfo.getResourceId() && sMethod === HTTPMethod.GET) {
 			mParameters = merge(mParameters,this.oDefaultQueryParams);
+		}
+
+		if (!mParameters._format || !this._isFormatSupported(mParameters._format)) {
+			mParameters._format = "json";
 		}
 
 		aQuery = [];
@@ -527,7 +527,7 @@ sap.ui.define([
 	 * @param {string} sFormat the format in a particular request
 	 * @returns {boolean} Whether its valid or not
 	 * @private
-	 * @since 1.1.1
+	 * @since 1.1.2
 	 */
 	FHIRRequestor.prototype._isFormatSupported = function(sFormat) {
 		var aSupportedFormats = [

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -14,9 +14,10 @@ sap.ui.define([
 	"sap/fhir/model/r4/lib/RequestHandle",
 	"sap/fhir/model/r4/lib/HTTPMethod",
 	"sap/fhir/model/r4/lib/FHIRUrl",
-	"sap/base/util/each"
+	"sap/base/util/each",
+	"sap/base/util/merge"
 ], function(jQuery, FHIRUtils, SubmitMode, FHIRBundle,
-	FHIRBundleEntry, FHIRBundleRequest, FHIRBundleType, RequestHandle, HTTPMethod, FHIRUrl, each) {
+	FHIRBundleEntry, FHIRBundleRequest, FHIRBundleType, RequestHandle, HTTPMethod, FHIRUrl, each, merge) {
 	"use strict";
 
 	/**
@@ -26,7 +27,7 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {boolean} bCSRF If the FHIR service supports the csrf token
 	 * @param {string} sPrefer In which kind the FHIR service shall return the responses described here https://www.hl7.org/fhir/http.html#2.21.0.5.2
-	 * @param {array}  aDefaultQueryParams The default query parameters to be passed to for all GET requests if there is no specific resource level params. It should be of type key:value pairs in the array E.g. {'_total':'accurate'}
+	 * @param {object} oDefaultQueryParams The default query parameters to be passed to for GET ALL requests that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @alias sap.fhir.model.r4.lib.FHIRRequestor
 	 * @author SAP SE
 	 * @constructs {FHIRRequestor} Provides the implementation of the FHIR Requestor to send and retrieve content from a FHIR server
@@ -34,14 +35,14 @@ sap.ui.define([
 	 * @since 1.0.0
 	 * @version ${version}
 	 */
-	var FHIRRequestor = function(sServiceUrl, oModel, bCSRF, sPrefer , aDefaultQueryParams) {
+	var FHIRRequestor = function(sServiceUrl, oModel, bCSRF, sPrefer , oDefaultQueryParams) {
 		this._mBundleQueue = {};
 		this.oModel = oModel;
 		this._sServiceUrl = sServiceUrl;
 		this._aPendingRequestHandles = [];
 		this.bCSRF = bCSRF === true ? true : false;
 		this.sPrefer = sPrefer ?  "return=minimal" : sPrefer;
-		this.aDefaultQueryParams = aDefaultQueryParams;
+		this.oDefaultQueryParams = oDefaultQueryParams;
 		this._oRegex = {
 			rAmpersand : /&/g,
 			rEquals : /\=/g,
@@ -422,15 +423,12 @@ sap.ui.define([
 			return "";
 		}
 
-		// according to fhir all these kinds shall be intrepreted as json
-		if (!mParameters._format || !(mParameters._format in ["json", "application/json", "application/fhir+json"])) {
+		if (!mParameters._format || !this._isFormatSupported(mParameters._format)) {
 			mParameters._format = "json";
 		}
 
 		if (!oBindingInfo.getResourceId() && sMethod === HTTPMethod.GET) {
-			this.aDefaultQueryParams.forEach(function (oItem) {
-				Object.assign(mParameters, oItem);
-			});
+			mParameters = merge(mParameters,this.oDefaultQueryParams);
 		}
 
 		aQuery = [];
@@ -521,6 +519,23 @@ sap.ui.define([
 			mResponseHeaders[aKeyValue[0]] = jqXHR.getResponseHeader(aKeyValue[0]);
 		}
 		return mResponseHeaders;
+	};
+
+	/**
+	 * checks if the _format is part of supported types
+	 * according to fhir all these kinds shall be intrepreted as json
+	 * @param {string} sFormat the format in a particular request
+	 * @returns {boolean} Whether its valid or not
+	 * @private
+	 * @since 1.1.1
+	 */
+	FHIRRequestor.prototype._isFormatSupported = function(sFormat) {
+		var aSupportedFormats = [
+			"json",
+			"application/json",
+			"application/fhir+json"
+		];
+		return sFormat in aSupportedFormats;
 	};
 
 	return FHIRRequestor;

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -27,7 +27,7 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {boolean} bCSRF If the FHIR service supports the csrf token
 	 * @param {string} sPrefer In which kind the FHIR service shall return the responses described here https://www.hl7.org/fhir/http.html#2.21.0.5.2
-	 * @param {object} oDefaultQueryParams The default query parameters to be passed as part of GET ALL requests and that are not specific to any particular resource(e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
+	 * @param {object} oDefaultQueryParams The default query parameters to be passed on resource type specific requests and not resource instance specific request (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @alias sap.fhir.model.r4.lib.FHIRRequestor
 	 * @author SAP SE
 	 * @constructs {FHIRRequestor} Provides the implementation of the FHIR Requestor to send and retrieve content from a FHIR server

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -35,7 +35,7 @@ sap.ui.define([
 	 * @since 1.0.0
 	 * @version ${version}
 	 */
-	var FHIRRequestor = function(sServiceUrl, oModel, bCSRF, sPrefer , oDefaultQueryParams) {
+	var FHIRRequestor = function(sServiceUrl, oModel, bCSRF, sPrefer, oDefaultQueryParams) {
 		this._mBundleQueue = {};
 		this.oModel = oModel;
 		this._sServiceUrl = sServiceUrl;
@@ -522,10 +522,10 @@ sap.ui.define([
 	};
 
 	/**
-	 * checks if the _format is part of supported types
-	 * according to fhir all these kinds shall be intrepreted as json
-	 * @param {string} sFormat the format in a particular request
-	 * @returns {boolean} Whether its valid or not
+	 * Checks if the _format is part of supported types (according to fhir all these kinds shall be intrepreted as json)
+	 * 
+	 * @param {string} sFormat The format in a particular request
+	 * @returns {boolean} Whether its supported or not
 	 * @private
 	 * @since 1.1.2
 	 */

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -424,10 +424,10 @@ sap.ui.define([
 		}
 
 		if (!oBindingInfo.getResourceId() && sMethod === HTTPMethod.GET) {
-			mParameters = merge(mParameters,this.oDefaultQueryParams);
+			mParameters = merge(mParameters, this.oDefaultQueryParams);
 		}
 
-		if (!mParameters._format || !this._isFormatSupported(mParameters._format)) {
+		if (!this._isFormatSupported(mParameters._format)) {
 			mParameters._format = "json";
 		}
 
@@ -535,7 +535,7 @@ sap.ui.define([
 			"application/json",
 			"application/fhir+json"
 		];
-		return sFormat in aSupportedFormats;
+		return aSupportedFormats.indexOf(sFormat) >= 0;
 	};
 
 	return FHIRRequestor;

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -523,7 +523,7 @@ sap.ui.define([
 
 	/**
 	 * Checks if the _format is part of supported types (according to fhir all these kinds shall be intrepreted as json)
-	 * 
+	 *
 	 * @param {string} sFormat The format in a particular request
 	 * @returns {boolean} Whether its supported or not
 	 * @private

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -72,7 +72,7 @@ sap.ui.define([
 	QUnit.test("check if response has no total property that error in list binding is thrown", function(assert) {
 		var sPath = "/Patient";
 		var oListBinding = this.oFhirModel.bindList(sPath);
-		TestUtilsIntegration.manipulateResponse("http://localhost:8080/fhir/R4/Patient?_count=10&_format=json&_total=accurate", this.oFhirModel, TestUtilsIntegration.setTotalUndefined, TestUtilsIntegration.checkErrorMsg.bind(undefined, this.oFhirModel, assert, "FHIR Server error: The \"total\" property is missing in the response for the requested FHIR resource " + sPath));
+		TestUtilsIntegration.manipulateResponse("http://localhost:8080/fhir/R4/Patient?_count=10&_total=accurate&_format=json", this.oFhirModel, TestUtilsIntegration.setTotalUndefined, TestUtilsIntegration.checkErrorMsg.bind(undefined, this.oFhirModel, assert, "FHIR Server error: The \"total\" property is missing in the response for the requested FHIR resource " + sPath));
 		oListBinding.getContexts();
 	});
 
@@ -507,7 +507,7 @@ sap.ui.define([
 			done();
 			assert.strictEqual(TestUtils.getQueryParameters(oRequestHandle.getUrl())._total, "accurate");
 		};
-		TestUtilsIntegration.checkSendRequest("http://localhost:8080/fhir/R4/Patient?_format=json&_total=accurate", this.oFhirModel, fnCheck);
+		TestUtilsIntegration.checkSendRequest("http://localhost:8080/fhir/R4/Patient?_total=accurate&_format=json", this.oFhirModel, fnCheck);
 		this.oFhirModel.bindContext("/Patient");
 	});
 

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -51,7 +51,8 @@ sap.ui.define([
 						"submit":"Transaction",
 						"fullUrlType":"url"
 					}
-				}
+				},
+				"defaultQueryParameters":[{"_total":"accurate"}]
 			};
 			this.oMessageModel = sap.ui.getCore().getMessageManager().getMessageModel();
 			this.oFhirModel = createModel(mParameters);

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -52,7 +52,7 @@ sap.ui.define([
 						"fullUrlType":"url"
 					}
 				},
-				"defaultQueryParameters":[{"_total":"accurate"}]
+				"defaultQueryParameters":{"_total":"accurate"}
 			};
 			this.oMessageModel = sap.ui.getCore().getMessageManager().getMessageModel();
 			this.oFhirModel = createModel(mParameters);

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -52,7 +52,7 @@ sap.ui.define([
 						"fullUrlType":"url"
 					}
 				},
-				"defaultQueryParameters":{"_total":"accurate"}
+				"defaultQueryParameters": { "_total": "accurate" }
 			};
 			this.oMessageModel = sap.ui.getCore().getMessageManager().getMessageModel();
 			this.oFhirModel = createModel(mParameters);

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -166,8 +166,8 @@ sap.ui.define([
 
 	QUnit.test("check that format request parameter", function(assert) {
 		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters(), "");
-		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({_format : "xml"}, this.oFhirModel1.getBindingInfo("/Patient")), "?_format=json&_total=accurate");
-		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({_format : "xml"}, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=json");
+		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "xml" }, this.oFhirModel1.getBindingInfo("/Patient")), "?_format=json&_total=accurate");
+		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "xml" }, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=json");
 	});
 
 	QUnit.test("check listbinding getcontexts in relative case for different depths of paths when resource gets newly created", function(assert) {
@@ -442,7 +442,7 @@ sap.ui.define([
 
 	QUnit.test("loadData without parameters", function(assert) {
 		var oRequestHandle = this.oFhirModel1.loadData("/Patient");
-		assert.equal(oRequestHandle.getUrl(), "https://example.com/fhir/Patient?_format=json&_total=accurate");
+		assert.equal(oRequestHandle.getUrl(), "https://example.com/fhir/Patient?_total=accurate&_format=json");
 
 		var oRequestHandle1 = this.oFhirModel1.loadData("/Patient/123");
 		assert.equal(oRequestHandle1.getUrl(), "https://example.com/fhir/Patient/123?_format=json");
@@ -451,7 +451,7 @@ sap.ui.define([
 	QUnit.test("loadData with csrf token", function(assert) {
 		this.oFhirModel2.oRequestor.sToken = "123";
 		var oRequestHandle = this.oFhirModel2.loadData("/Patient");
-		assert.equal(oRequestHandle.getUrl(), "https://example.com/fhir/Patient?_format=json&_total=accurate");
+		assert.equal(oRequestHandle.getUrl(), "https://example.com/fhir/Patient?_total=accurate&_format=json");
 		this.oFhirModel2.oRequestor.sToken = undefined;
 	});
 

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -50,12 +50,13 @@ sap.ui.define([
 					"valueSets" : {
 						"submit" : "Batch"
 					}
-				}
+				},
+				"defaultQueryParameters":[{"_total":"accurate"}]
 			};
 
 			this.oRequestHandle = TestUtils.createRequestHandle();
 			this.oFhirModel1 = createModel(mParameters);
-			this.oFhirModel2 = createModel({"x-csrf-token" : true});
+			this.oFhirModel2 = createModel({ "x-csrf-token": true, "defaultQueryParameters": [{ "_total": "accurate" }] });
 			this.oFhirModel3 = createModel(mParameters);
 			this.loadDataIntoModel = function(sFilePath, sResourcePath, mParams, sMethod) {
 				var mResponseHeaders = {"etag" : "W/\"1\""};

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -51,12 +51,12 @@ sap.ui.define([
 						"submit" : "Batch"
 					}
 				},
-				"defaultQueryParameters":[{"_total":"accurate"}]
+				"defaultQueryParameters":{"_total":"accurate"}
 			};
 
 			this.oRequestHandle = TestUtils.createRequestHandle();
 			this.oFhirModel1 = createModel(mParameters);
-			this.oFhirModel2 = createModel({ "x-csrf-token": true, "defaultQueryParameters": [{ "_total": "accurate" }] });
+			this.oFhirModel2 = createModel({ "x-csrf-token": true, "defaultQueryParameters": { "_total": "accurate" } });
 			this.oFhirModel3 = createModel(mParameters);
 			this.loadDataIntoModel = function(sFilePath, sResourcePath, mParams, sMethod) {
 				var mResponseHeaders = {"etag" : "W/\"1\""};

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -168,6 +168,9 @@ sap.ui.define([
 		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters(), "");
 		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "xml" }, this.oFhirModel1.getBindingInfo("/Patient")), "?_format=json&_total=accurate");
 		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "xml" }, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=json");
+		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "application/json" }, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=application/json");
+		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "application/fhir+json" }, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=application/fhir%2Bjson");
+		assert.strictEqual(this.oFhirModel1.oRequestor._buildQueryParameters({ _format: "json" }, this.oFhirModel1.getBindingInfo("/Patient/123")), "?_format=json");
 	});
 
 	QUnit.test("check listbinding getcontexts in relative case for different depths of paths when resource gets newly created", function(assert) {

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -51,7 +51,7 @@ sap.ui.define([
 						"submit" : "Batch"
 					}
 				},
-				"defaultQueryParameters":{"_total":"accurate"}
+				"defaultQueryParameters": { "_total": "accurate" }
 			};
 
 			this.oRequestHandle = TestUtils.createRequestHandle();

--- a/test/qunit/model/FHIRTreeBinding.integration.js
+++ b/test/qunit/model/FHIRTreeBinding.integration.js
@@ -30,7 +30,7 @@ sap.ui.define([
 		var sPath = "/StructureDefinition";
 		var mParameters = { rootSearch: "base", rootProperty: "baseDefinition", rootValue: "http://hl7.org/fhir/StructureDefinition/DomainResource", nodeProperty: "url", refreshByExpand: "true" };
 		createTreeBinding(sPath, undefined, undefined, mParameters);
-		TestUtilsIntegration.manipulateResponse("http://localhost:8080/fhir/R4/StructureDefinition?base=http://hl7.org/fhir/StructureDefinition/DomainResource&_count=10&_format=json&_total=accurate", oModel, TestUtilsIntegration.setTotalUndefined, TestUtilsIntegration.checkErrorMsg.bind(undefined, oModel, assert, "FHIR Server error: The \"total\" property is missing in the response for the requested FHIR resource " + sPath));
+		TestUtilsIntegration.manipulateResponse("http://localhost:8080/fhir/R4/StructureDefinition?base=http://hl7.org/fhir/StructureDefinition/DomainResource&_count=10&_total=accurate&_format=json", oModel, TestUtilsIntegration.setTotalUndefined, TestUtilsIntegration.checkErrorMsg.bind(undefined, oModel, assert, "FHIR Server error: The \"total\" property is missing in the response for the requested FHIR resource " + sPath));
 		oTreeBinding.getContexts();
 	});
 

--- a/test/qunit/model/FHIRTreeBinding.integration.js
+++ b/test/qunit/model/FHIRTreeBinding.integration.js
@@ -9,6 +9,8 @@ sap.ui.define([
 	var oModel, oTreeBinding;
 
 	function createModel(mParameters) {
+		mParameters = {};
+		mParameters.defaultQueryParameters = { "_total": "accurate" };
 		oModel = TestUtils.createFHIRModel("http://localhost:8080/fhir/R4", mParameters);
 	}
 

--- a/test/sap-fhir-test-app/webapp/manifest.json
+++ b/test/sap-fhir-test-app/webapp/manifest.json
@@ -97,7 +97,7 @@
 					},
 					"x-csrf-token" : false,
 					"Prefer" : "return=representation",
-					"defaultQueryParameters":[{"_total":"accurate"}]
+					"defaultQueryParameters":{"_total":"accurate"}
 				}
 			},
 			"client": {

--- a/test/sap-fhir-test-app/webapp/manifest.json
+++ b/test/sap-fhir-test-app/webapp/manifest.json
@@ -96,7 +96,8 @@
 						}
 					},
 					"x-csrf-token" : false,
-					"Prefer" : "return=representation"
+					"Prefer" : "return=representation",
+					"defaultQueryParameters":[{"_total":"accurate"}]
 				}
 			},
 			"client": {

--- a/test/sap-fhir-test-app/webapp/manifest.json
+++ b/test/sap-fhir-test-app/webapp/manifest.json
@@ -97,7 +97,9 @@
 					},
 					"x-csrf-token" : false,
 					"Prefer" : "return=representation",
-					"defaultQueryParameters":{"_total":"accurate"}
+					"defaultQueryParameters": {
+						"_total": "accurate"
+					}
 				}
 			},
 			"client": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "system",
+    "target": "es6",
     "sourceMap": true,
     "noEmit": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "system",
-    "target": "es6",
     "sourceMap": true,
     "noEmit": true,
     "allowJs": true,


### PR DESCRIPTION
The default query parameters to be passed on resource type specific requests and not resource instance specific request (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters