### PR TITLE
fix: in case the location header has slash at the beginning

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -348,6 +348,10 @@ sap.ui.define([
 	 * @since 1.0.0
 	 */
 	FHIRModel.prototype._getUpdatedResourceFromFHIRResponse = function(mResponseHeaders, oFHIRBundleEntry){
+		// remove possible slash at the beginning
+		if (mResponseHeaders.location && mResponseHeaders.location.charAt(0) === "/") {
+			mResponseHeaders.location = mResponseHeaders.location.slice(1);
+		}
 		var oBindingInfo = this.getBindingInfo("/" + mResponseHeaders.location);
 		var oRes;
 		if (oFHIRBundleEntry){

--- a/test/localService/ResponseOfMultiplePutInBundle.json
+++ b/test/localService/ResponseOfMultiplePutInBundle.json
@@ -20,7 +20,7 @@
         {
             "response": {
                 "status": "200 OK",
-                "location": "Patient/254/_history/4",
+                "location": "/Patient/254/_history/4",
                 "etag": "4",
                 "lastModified": "2018-08-09T17:12:07.383+02:00"
             }

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1161,10 +1161,10 @@ sap.ui.define([
 		var mResponseHeaders = { "etag": "W/\"1\"", "location": sPatientPath + "/_history/1" };
 		var oBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, undefined);
 		var oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oUpdatedResource.id, sResourceId, "Location with / at the beginning gives proper response and doesnot throw error");
+		assert.strictEqual(oUpdatedResource.id, sResourceId, "Response with location having / at the beginning gives proper resource object and doesnot throw error");
 		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
 		oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oUpdatedResource.id, sResourceId, "Location without / at the beginning gives proper response and doesnot throw error");
+		assert.strictEqual(oUpdatedResource.id, sResourceId, "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
 	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1164,7 +1164,7 @@ sap.ui.define([
 		assert.strictEqual(oUpdatedResource.id, sResourceId, "Location with / at the beginning gives proper response and doesnot throw error");
 		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
 		oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oResource.id, sResourceId, "Location without / at the beginning gives proper response and doesnot throw error");
+		assert.strictEqual(oUpdatedResource.id, sResourceId, "Location without / at the beginning gives proper response and doesnot throw error");
 	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -13,9 +13,8 @@ sap.ui.define([
 	"sap/fhir/model/r4/SubmitMode",
 	"sap/fhir/model/r4/lib/FHIRBundleType",
 	"sap/fhir/model/r4/lib/FHIRBundleRequest",
-	"sap/base/util/deepEqual",
-	"sap/fhir/model/r4/lib/FHIRBundleEntry"
-], function(jQuery, TestUtils, FHIRFilter, FHIRFilterType, FHIRFilterOperator, FHIRFilterProcessor, OperationMode, RequestHandle, Sliceable, FilterOperator, Filter, SubmitMode, FHIRBundleType, FHIRBundleRequest, deepEqual, FHIRBundleEntry) {
+	"sap/base/util/deepEqual"
+], function(jQuery, TestUtils, FHIRFilter, FHIRFilterType, FHIRFilterOperator, FHIRFilterProcessor, OperationMode, RequestHandle, Sliceable, FilterOperator, Filter, SubmitMode, FHIRBundleType, FHIRBundleRequest, deepEqual) {
 
 	"use strict";
 
@@ -1167,6 +1166,6 @@ sap.ui.define([
 		this.oFhirModel1.sendGetRequest(sPatientPath);
 		oResource = this.oFhirModel1.getProperty(sPatientPath);
 		assert.strictEqual(oResource.id, sResourceId, "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
-    });
+	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -13,8 +13,9 @@ sap.ui.define([
 	"sap/fhir/model/r4/SubmitMode",
 	"sap/fhir/model/r4/lib/FHIRBundleType",
 	"sap/fhir/model/r4/lib/FHIRBundleRequest",
-	"sap/base/util/deepEqual"
-], function(jQuery, TestUtils, FHIRFilter, FHIRFilterType, FHIRFilterOperator, FHIRFilterProcessor, OperationMode, RequestHandle, Sliceable, FilterOperator, Filter, SubmitMode, FHIRBundleType, FHIRBundleRequest, deepEqual) {
+	"sap/base/util/deepEqual",
+	"sap/fhir/model/r4/lib/FHIRBundleEntry"
+], function(jQuery, TestUtils, FHIRFilter, FHIRFilterType, FHIRFilterOperator, FHIRFilterProcessor, OperationMode, RequestHandle, Sliceable, FilterOperator, Filter, SubmitMode, FHIRBundleType, FHIRBundleRequest, deepEqual, FHIRBundleEntry) {
 
 	"use strict";
 
@@ -1143,4 +1144,27 @@ sap.ui.define([
 		}.bind(this));
 		assert.ok(bMatch, "The filter matched one of the given values for dummy property");
 	});
+
+	QUnit.test("Get Updated Resource from response when location has / or not shouldnot fail ", function(assert) {
+		var sResourceId = this.oFhirModel1.create("Patient", {
+			name: [
+				{
+					family: "james",
+					given: ["parker"]
+				}
+			]
+		});
+		var sPatientPath = "/Patient/" + sResourceId;
+		this.oFhirModel1.bindContext(sPatientPath);
+		var oResource = this.oFhirModel1.oData.Patient[sResourceId];
+		var sFullUrl = "urn:uuid:" + sResourceId;
+		var mResponseHeaders = { "etag": "W/\"1\"", "location": sPatientPath + "/_history/1" };
+		var oBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, undefined);
+		var oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
+		assert.strictEqual(oUpdatedResource.id, sResourceId);
+		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
+		oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
+		assert.strictEqual(oResource.id, sResourceId);
+	});
+
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1155,16 +1155,18 @@ sap.ui.define([
 			]
 		});
 		var sPatientPath = "/Patient/" + sResourceId;
-		this.oFhirModel1.bindContext(sPatientPath);
-		var oResource = this.oFhirModel1.getProperty(sPatientPath);
-		var sFullUrl = "urn:uuid:" + sResourceId;
 		var mResponseHeaders = { "etag": "W/\"1\"", "location": sPatientPath + "/_history/1" };
-		var oBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, undefined);
-		var oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oUpdatedResource.id, sResourceId, "Response with location having / at the beginning gives proper resource object and doesnot throw error");
+		this.oRequestHandle.setUrl("https://example.com/fhir/" + sPatientPath);
+		this.oRequestHandle.setRequest(TestUtils.createAjaxCallMock(mResponseHeaders));
+		this.oFhirModel1.sendGetRequest(sPatientPath);
+		var oResource = this.oFhirModel1.getProperty(sPatientPath);
+		assert.strictEqual(oResource.id, sResourceId, "Response with location having / at the beginning gives proper resource object and doesnot throw error");
 		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
-		oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oUpdatedResource.id, sResourceId, "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
-	});
+		this.oRequestHandle.setUrl("https://example.com/fhir/" + sPatientPath);
+		this.oRequestHandle.setRequest(TestUtils.createAjaxCallMock(mResponseHeaders));
+		this.oFhirModel1.sendGetRequest(sPatientPath);
+		oResource = this.oFhirModel1.getProperty(sPatientPath);
+		assert.strictEqual(oResource.id, sResourceId, "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
+    });
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1156,15 +1156,15 @@ sap.ui.define([
 		});
 		var sPatientPath = "/Patient/" + sResourceId;
 		this.oFhirModel1.bindContext(sPatientPath);
-		var oResource = this.oFhirModel1.oData.Patient[sResourceId];
+		var oResource = this.oFhirModel1.getProperty(sPatientPath);
 		var sFullUrl = "urn:uuid:" + sResourceId;
 		var mResponseHeaders = { "etag": "W/\"1\"", "location": sPatientPath + "/_history/1" };
 		var oBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, undefined);
 		var oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oUpdatedResource.id, sResourceId);
+		assert.strictEqual(oUpdatedResource.id, sResourceId, "Location with / at the beginning gives proper response and doesnot throw error");
 		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
 		oUpdatedResource = this.oFhirModel1._getUpdatedResourceFromFHIRResponse(mResponseHeaders, oBundleEntry);
-		assert.strictEqual(oResource.id, sResourceId);
+		assert.strictEqual(oResource.id, sResourceId, "Location without / at the beginning gives proper response and doesnot throw error");
 	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1145,27 +1145,16 @@ sap.ui.define([
 	});
 
 	QUnit.test("Get Updated Resource from response when location has / or not shouldnot fail ", function(assert) {
-		var sResourceId = this.oFhirModel1.create("Patient", {
-			name: [
-				{
-					family: "james",
-					given: ["parker"]
-				}
-			]
-		});
-		var sPatientPath = "/Patient/" + sResourceId;
-		var mResponseHeaders = { "etag": "W/\"1\"", "location": sPatientPath + "/_history/1" };
-		this.oRequestHandle.setUrl("https://example.com/fhir/" + sPatientPath);
-		this.oRequestHandle.setRequest(TestUtils.createAjaxCallMock(mResponseHeaders));
-		this.oFhirModel1.sendGetRequest(sPatientPath);
+		this.loadDataIntoModel("TwoUpdatedPatients");
+		var oJSONData = TestUtils.loadJSONFile("ResponseOfMultiplePutInBundle");
+		this.oRequestHandle.setUrl("https://example.com/fhir/");
+		this.oFhirModel1._onSuccessfulRequest(this.oRequestHandle, oJSONData);
+		var sPatientPath = "/Patient/253";
 		var oResource = this.oFhirModel1.getProperty(sPatientPath);
-		assert.strictEqual(oResource.id, sResourceId, "Response with location having / at the beginning gives proper resource object and doesnot throw error");
-		mResponseHeaders = { "etag": "W/\"1\"", "location": "Patient/" + sResourceId + "/_history/1" };
-		this.oRequestHandle.setUrl("https://example.com/fhir/" + sPatientPath);
-		this.oRequestHandle.setRequest(TestUtils.createAjaxCallMock(mResponseHeaders));
-		this.oFhirModel1.sendGetRequest(sPatientPath);
+		assert.strictEqual(oResource.id, "253", "Response with location having / at the beginning gives proper resource object and doesnot throw error");
+		sPatientPath = "/Patient/254";
 		oResource = this.oFhirModel1.getProperty(sPatientPath);
-		assert.strictEqual(oResource.id, sResourceId, "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
+		assert.strictEqual(oResource.id, "254", "Response with location without having / at the beginning gives proper resource object and doesnot throw error");
 	});
 
 });


### PR DESCRIPTION
When location header is of following "/Patient/3ac58844-5c7e-4b4f-8600-c0b836bfa48a/_history/f52ecc0d-16ef-4f5a-9183-9306f103685b"  the getBindingInfo fails throwing an error from model since extra / is getting appended.

TODO: Have a normalised function a central place to do this