### PR TITLE
fix: handling changed resources when the server state and the client state is the same

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -905,10 +905,10 @@ sap.ui.define([
 			oRequestInfo = this._createRequestInfo(HTTPMethod.POST, oBindingInfo.getResourceType());
 			this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath), oRequestInfo, true);
 		}
-		if (sGroupId){
+		if (sGroupId) {
 			this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath), sGroupId, true);
 		}
-		if (!vServerValue && oRequestInfo.method === HTTPMethod.PUT){
+		if (!vServerValue && oRequestInfo.method === HTTPMethod.PUT) {
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		}
 	};
@@ -927,7 +927,16 @@ sap.ui.define([
 		var oBindingInfo = this.getBindingInfo(sPath, oContext);
 		this._handleClientChanges(oBindingInfo);
 		this._setProperty(this.oData, oBindingInfo.getBinding(), vValue, undefined, oBindingInfo.getGroupId());
-		this.mChangedResources.path = {lastUpdated : oBindingInfo.getAbsolutePath()};
+		var aResPath = oBindingInfo.getResourcePathArray();
+		var vServerValue = this._getProperty(this.oDataServerState, aResPath);
+		var oRequestInfo = this._getProperty(this.mChangedResources, aResPath);
+		var oResource = this._getProperty(this.oData, aResPath);
+		// special handling when the server data and the client changed data is the same
+		if (oRequestInfo && oRequestInfo.method === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {
+			delete this.mChangedResources[aResPath[0]][aResPath[1]];
+		} else {
+			this.mChangedResources.path = { lastUpdated: oBindingInfo.getAbsolutePath() };
+		}
 		this.checkUpdate(false, this.mChangedResources, oBinding);
 	};
 
@@ -1208,7 +1217,7 @@ sap.ui.define([
 	 * @since 1.0.0
 	 */
 	FHIRModel.prototype.hasResourceTypePendingChanges = function(sResourceType) {
-		return this.mChangedResources[sResourceType] !== undefined;
+		return this.mChangedResources[sResourceType] !== undefined && Object.keys(this.mChangedResources[sResourceType]).length > 0;
 	};
 
 	/**

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -314,6 +314,10 @@ sap.ui.define([
 		this.loadDataIntoModel("Patient", this.sPatientPath.substring(1));
 		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-27");
 		assert.strictEqual(this.oFhirModel1.submitChanges(), undefined, "submit changes returns undefined because of no changes");
+		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-29");
+		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-27");
+		assert.strictEqual(this.oFhirModel1.submitChanges(), undefined, "submit changes returns undefined because the changes made is same as that of the server state");
+		assert.strictEqual(this.oFhirModel1.hasResourceTypePendingChanges("Patient"), false, "hasResourceTypePendingChanges returns false since there is no actual change");
 	});
 
 	QUnit.test("get group submit mode", function(assert) {

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -315,6 +315,7 @@ sap.ui.define([
 		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-27");
 		assert.strictEqual(this.oFhirModel1.submitChanges(), undefined, "submit changes returns undefined because of no changes");
 		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-29");
+		assert.strictEqual(this.oFhirModel1.hasResourceTypePendingChanges("Patient"), true, "hasResourceTypePendingChanges returns true since there is an actual change");
 		this.oFhirModel1.setProperty(this.sPatientPath + "/birthDate", "2008-04-27");
 		assert.strictEqual(this.oFhirModel1.submitChanges(), undefined, "submit changes returns undefined because the changes made is same as that of the server state");
 		assert.strictEqual(this.oFhirModel1.hasResourceTypePendingChanges("Patient"), false, "hasResourceTypePendingChanges returns false since there is no actual change");


### PR DESCRIPTION
hasResourceTypePendingChanges depends on the mChangedResources which gets updated even when the server data and the client data is the same.
