### PR TITLE
fix: dont trigger request failed for aborted requests

### DIFF
--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -108,7 +108,7 @@ sap.ui.define([
 				return oFHIRBundle;
 			} else {
 				oRequestHandle = this._mBundleQueue[sGroupId];
-				if (oRequestHandle && oRequestHandle instanceof RequestHandle) {
+				if (oRequestHandle && oRequestHandle instanceof RequestHandle){
 					oRequestHandle.getRequest().abort();
 				}
 				oRequestHandle = this._sendBundle(oFHIRBundle);

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -109,7 +109,6 @@ sap.ui.define([
 			} else {
 				oRequestHandle = this._mBundleQueue[sGroupId];
 				if (oRequestHandle && oRequestHandle instanceof RequestHandle) {
-					oRequestHandle.bAborted = true;
 					oRequestHandle.getRequest().abort();
 				}
 				oRequestHandle = this._sendBundle(oFHIRBundle);
@@ -337,7 +336,7 @@ sap.ui.define([
 		jqXHR.fail(function(oGivenRequestHandle) {
 			this._deleteRequestHandle(oGivenRequestHandle);
 			fnError(oGivenRequestHandle);
-			if (!oGivenRequestHandle.bAborted) {
+			if (!oGivenRequestHandle.isAborted()) {
 				this.oModel.fireRequestFailed(this._createEventParameters(oGivenRequestHandle));
 			}
 		}.bind(this, oRequestHandle));

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -108,7 +108,8 @@ sap.ui.define([
 				return oFHIRBundle;
 			} else {
 				oRequestHandle = this._mBundleQueue[sGroupId];
-				if (oRequestHandle && oRequestHandle instanceof RequestHandle){
+				if (oRequestHandle && oRequestHandle instanceof RequestHandle) {
+					oRequestHandle.bAborted = true;
 					oRequestHandle.getRequest().abort();
 				}
 				oRequestHandle = this._sendBundle(oFHIRBundle);
@@ -336,7 +337,9 @@ sap.ui.define([
 		jqXHR.fail(function(oGivenRequestHandle) {
 			this._deleteRequestHandle(oGivenRequestHandle);
 			fnError(oGivenRequestHandle);
-			this.oModel.fireRequestFailed(this._createEventParameters(oGivenRequestHandle));
+			if (!oGivenRequestHandle.bAborted) {
+				this.oModel.fireRequestFailed(this._createEventParameters(oGivenRequestHandle));
+			}
 		}.bind(this, oRequestHandle));
 	};
 

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -308,8 +308,8 @@ sap.ui.define([
 	 */
 	FHIRRequestor.prototype._ajax = function(oRequestHandle, mParameters, fnSuccess, fnError) {
 		var jqXHR = jQuery.ajax(mParameters);
-		if (jqXHR.statusText !== "canceled") {
-			jqXHR.complete(function(oGivenRequestHandle) {
+		if (!oRequestHandle.isAborted()) {
+			jqXHR.complete(function (oGivenRequestHandle) {
 				this.oModel.fireRequestCompleted(this._createEventParameters(oGivenRequestHandle));
 			}.bind(this, oRequestHandle));
 			this._add(oRequestHandle, fnSuccess, fnError);

--- a/src/sap/fhir/model/r4/lib/RequestHandle.js
+++ b/src/sap/fhir/model/r4/lib/RequestHandle.js
@@ -180,14 +180,14 @@ sap.ui.define([ "sap/fhir/model/r4/FHIRUtils" ], function(FHIRUtils) {
 
 
 	/**
-	 * Checks if the request is aborted
+	 * Checks if the request is aborted or canceled
 	 *
-	 * @returns {boolean} true if the request is aborted
+	 * @returns {boolean} true if the request is aborted or canceled
 	 * @public
 	 * @since 2.0.1
 	 */
 	RequestHandle.prototype.isAborted = function () {
-		return this.getRequest().statusText === "abort";
+		return this.getRequest().statusText === "abort" || this.getRequest().statusText === "canceled";
 	};
 
 	return RequestHandle;

--- a/src/sap/fhir/model/r4/lib/RequestHandle.js
+++ b/src/sap/fhir/model/r4/lib/RequestHandle.js
@@ -183,7 +183,7 @@ sap.ui.define([ "sap/fhir/model/r4/FHIRUtils" ], function(FHIRUtils) {
 	 * Checks if the request is aborted or canceled
 	 *
 	 * @returns {boolean} true if the request is aborted or canceled
-	 * @public
+	 * @protected
 	 * @since 2.0.1
 	 */
 	RequestHandle.prototype.isAborted = function () {

--- a/src/sap/fhir/model/r4/lib/RequestHandle.js
+++ b/src/sap/fhir/model/r4/lib/RequestHandle.js
@@ -178,5 +178,17 @@ sap.ui.define([ "sap/fhir/model/r4/FHIRUtils" ], function(FHIRUtils) {
 		this.getRequest().abort();
 	};
 
+
+	/**
+	 * Checks if the request is aborted
+	 *
+	 * @returns {boolean} true if the request is aborted
+	 * @public
+	 * @since 2.0.1
+	 */
+	RequestHandle.prototype.isAborted = function() {
+		return this.getRequest().statusText === "abort";
+	};
+
 	return RequestHandle;
 });

--- a/src/sap/fhir/model/r4/lib/RequestHandle.js
+++ b/src/sap/fhir/model/r4/lib/RequestHandle.js
@@ -186,7 +186,7 @@ sap.ui.define([ "sap/fhir/model/r4/FHIRUtils" ], function(FHIRUtils) {
 	 * @public
 	 * @since 2.0.1
 	 */
-	RequestHandle.prototype.isAborted = function() {
+	RequestHandle.prototype.isAborted = function () {
 		return this.getRequest().statusText === "abort";
 	};
 

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1205,4 +1205,14 @@ sap.ui.define([
 		assert.strictEqual(sStrucDefUrl, undefined, "Structure definition URL is undefined since resource type doesnot exist");
 	});
 
+	QUnit.test("RequestHandle isAborted should be true for aborted requests", function(assert){
+		this.loadDataIntoModel("Patient2", this.sPatientPath2.substring(1));
+		this.oPropertyBinding3.setValue("2008-04-27");
+		var mRequestHandles = this.oFhirModel1.submitChanges();
+		var oRequestHandlePatient = mRequestHandles.patientDetails;
+		assert.equal(oRequestHandlePatient.isAborted(), false);
+		oRequestHandlePatient.abort();
+		assert.equal(oRequestHandlePatient.isAborted(), true);
+	});
+
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1215,4 +1215,11 @@ sap.ui.define([
 		assert.equal(oRequestHandlePatient.isAborted(), true);
 	});
 
+	QUnit.test("RequestHandle isAborted should be true for canceled requests", function(assert){
+		var oRequestHandle = this.oFhirModel1.sendGetRequest("dummy");
+		assert.equal(oRequestHandle.isAborted(), false);
+		oRequestHandle = this.oFhirModel1.sendGetRequest("dummy");
+		assert.equal(oRequestHandle.isAborted(), true);
+	});
+
 });

--- a/test/sap-fhir-test-app/webapp/controller/structureDefinition/StructureDefinition.controller.js
+++ b/test/sap-fhir-test-app/webapp/controller/structureDefinition/StructureDefinition.controller.js
@@ -98,11 +98,9 @@ sap.ui.define([
 
 		onFailureSave : function(oError, aResource, aOperationOutcome) {
 			this.closeStructureDefinitionBusyDialog();
-			if (oError.statusText !== "abort") {
-				MessageBox.error(Utils.getI18nText(this.getView(), "structureDefinitionMsgSaveFailed", [ oError.message ]), {
-					styleClass : this.getOwnerComponent().getContentDensityClass()
-				});
-			}
+			MessageBox.error(Utils.getI18nText(this.getView(), "structureDefinitionMsgSaveFailed", [oError.message]), {
+				styleClass: this.getOwnerComponent().getContentDensityClass()
+			});
 		},
 
 		createStructDef : function() {


### PR DESCRIPTION
For intentional aborted requests dont trigger fireRequestFailed/fireRequestCompleted Event
https://github.com/SAP/openui5/blob/master/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js#L869