### PR TITLE
fix: ValueSet calls without expand option

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -317,8 +317,8 @@ sap.ui.define([
 	 */
 	FHIRModel.prototype._storeResourceInModel = function(oResource, oBinding, sGroupId) {
 		var aResourcePath;
-		if (oResource.resourceType === "ValueSet") {
-			aResourcePath = [oResource.resourceType , "§" + oResource.expansion.identifier + "§"];
+		if (oResource.resourceType === "ValueSet" && oResource.expansion && oResource.expansion.identifier) {
+			aResourcePath = [oResource.resourceType, "§" + oResource.expansion.identifier + "§"];
 			oResource = oResource.expansion.contains;
 		} else {
 			// generate a uuid id in case resource id is not present in the response
@@ -425,7 +425,7 @@ sap.ui.define([
 	 */
 	FHIRModel.prototype._mapResourceToResourceMap = function(oData) {
 		var mResources = {};
-		if (oData && oData.resourceType === "ValueSet") {
+		if (oData && oData.resourceType === "ValueSet" && oData.expansion && oData.expansion.identifier) {
 			this._setProperty(mResources, ["ValueSet", "§" + oData.expansion.identifier + "§"], oData.expansion.contains, true);
 		} else if (oData && oData.resourceType && oData.id && oData.resourceType !== "Bundle") {
 			this._setProperty(mResources, [oData.resourceType, oData.id], oData, true);

--- a/test/localService/ValueSetSearchResponse.json
+++ b/test/localService/ValueSetSearchResponse.json
@@ -1,0 +1,68 @@
+{
+    "resourceType": "Bundle",
+    "id": "d9b3ce9c-b077-4a67-b2b9-5c2504984789",
+    "meta": {
+        "lastUpdated": "2020-11-04T16:33:34.951+00:00"
+    },
+    "type": "searchset",
+    "total": 1,
+    "entry": [
+        {
+            "fullUrl": "http://hapi.fhir.org/baseR4/ValueSet/sact-location-medication-collection-code",
+            "resource": {
+                "resourceType": "ValueSet",
+                "id": "sact-location-medication-collection-code",
+                "meta": {
+                    "versionId": "1",
+                    "lastUpdated": "2020-11-04T00:38:37.191+00:00",
+                    "source": "#JyzM1qvlAHO91tyy"
+                },
+                "url": "https://standards.digital.health.nz/fhir/ValueSet/sact-location-medication-collection-code",
+                "version": "0.1.0",
+                "name": "LocationMedicationCollection",
+                "title": "Medication collection location",
+                "status": "active",
+                "date": "2020-11-04T13:33:02+13:00",
+                "publisher": "David Hay",
+                "contact": [
+                    {
+                        "name": "David Hay",
+                        "telecom": [
+                            {
+                                "system": "email",
+                                "value": "mailto:david.hay25@gmail.com"
+                            }
+                        ]
+                    }
+                ],
+                "description": "The physical location where the medication can be collected on prior to administration - eg a pharmacy",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "NZ"
+                            }
+                        ]
+                    }
+                ],
+                "compose": {
+                    "include": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "concept": [
+                                {
+                                    "code": "284748001",
+                                    "display": "Pharmacy shop"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "search": {
+                "mode": "match"
+            }
+        }
+    ]
+}

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1222,4 +1222,15 @@ sap.ui.define([
 		assert.equal(oRequestHandle.isAborted(), true);
 	});
 
+	QUnit.test("ValueSet search response should not throw error", function(assert){
+		var oJSONData = TestUtils.loadJSONFile("ValueSetSearchResponse");
+		var mResponseHeaders = { "etag": "W/\"1\"" };
+		this.oRequestHandle.setUrl("https://example.com/fhir/ValueSet?url=https://standards.digital.health.nz/fhir/ValueSet/sact-location-medication-collection-code");
+		this.oRequestHandle.setRequest(TestUtils.createAjaxCallMock(mResponseHeaders));
+		this.oFhirModel1._onSuccessfulRequest(this.oRequestHandle, oJSONData);
+		var sValueSetPath = "/ValueSet/sact-location-medication-collection-code";
+		var oValueSet = this.oFhirModel1.getProperty(sValueSetPath);
+		assert.strictEqual(oValueSet.url, "https://standards.digital.health.nz/fhir/ValueSet/sact-location-medication-collection-code", "ValueSet Search Response is saved in the model data without throwing an error");
+	});
+
 });


### PR DESCRIPTION
When ValueSet requests are made without the expand option the model doesn't map the response causing console logs.
![error2](https://user-images.githubusercontent.com/59359754/98142766-3aa6ed00-1eee-11eb-9f39-826635f3a0c0.PNG)
