### PR TITLE
fix: forceful update of server state variable in handleClient changes for multiple reset changes scenario

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1521,12 +1521,12 @@ sap.ui.define([
 				if (oRequestInfo.method === HTTPMethod.PUT){
 					var oResourceServerState = this._getProperty(this.oDataServerState, aResPath);
 					this._setProperty(this.oData, FHIRUtils.deepClone(aResPath), oResourceServerState);
-					this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				} else if (oRequestInfo.method === HTTPMethod.POST){
 					this._setProperty(this.oData, FHIRUtils.deepClone(aResPath));
 					this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 					this._removeFromOrderResources(oBindingInfo);
 				}
+				this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
 			}.bind(this);
 			if (sResGroupId === sGroupId){

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1526,7 +1526,9 @@ sap.ui.define([
 					this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 					this._removeFromOrderResources(oBindingInfo);
 				}
-				this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
+				if (Object.keys(this.oDataServerState).length > 0 && this.oDataServerState[aResPath[0]] != undefined && this.oDataServerState[aResPath[0]][aResPath[1]] != undefined) {
+					this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
+				}
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
 			}.bind(this);
 			if (sResGroupId === sGroupId){

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1521,12 +1521,12 @@ sap.ui.define([
 				if (oRequestInfo.method === HTTPMethod.PUT){
 					var oResourceServerState = this._getProperty(this.oDataServerState, aResPath);
 					this._setProperty(this.oData, FHIRUtils.deepClone(aResPath), oResourceServerState);
+					this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				} else if (oRequestInfo.method === HTTPMethod.POST){
 					this._setProperty(this.oData, FHIRUtils.deepClone(aResPath));
 					this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 					this._removeFromOrderResources(oBindingInfo);
 				}
-				this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
 			}.bind(this);
 			if (sResGroupId === sGroupId){

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1607,7 +1607,7 @@ sap.ui.define([
 	 *
 	 * @param {object} vServerValue Existing server state value
 	 * @param {object} oResource The FHIR resource
-	 * @param {string} sHTTPMethod HTTP Method for the resource
+	 * @param {sap.fhir.model.r4.HTTPMethod} sHTTPMethod HTTP Method for the resource
 	 * @returns {boolean} if true then server state variable will not be updated
 	 * @private
 	 * @since 2.0.4

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -951,11 +951,7 @@ sap.ui.define([
 		if (sGroupId) {
 			this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath), sGroupId, true);
 		}
-		if (!vServerValue && oRequestInfo.method === HTTPMethod.PUT) {
-			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
-		} else if (vServerValue && oRequestInfo.method === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {
-			// special handling when the server data and the client data before applying the change is the same(after multiple reset changes)
-			// forcefully update the existing server state
+		if (!this._isServerDateUpToDate(vServerValue, oResource, oRequestInfo.method)) {
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		}
 	};
@@ -1604,6 +1600,27 @@ sap.ui.define([
 			sStrucDefUrl = this.getBaseProfileUrl() + oResource.resourceType;
 		}
 		return sStrucDefUrl;
+	};
+
+	/**
+	 * Determines whether server state variable needs an update
+	 *
+	 * @param {object} vServerValue Existing server state value
+	 * @param {object} oResource The FHIR resource
+	 * @param {string} sHTTPMethod HTTP Method for the resource
+	 * @returns {boolean} if true then server state variable will not be updated
+	 * @private
+	 * @since 2.0.4
+	 */
+	FHIRModel.prototype._isServerDateUpToDate = function(vServerValue, oResource, sHTTPMethod){
+		if (!vServerValue && sHTTPMethod === HTTPMethod.PUT) {
+			return false;
+		} else if (vServerValue && sHTTPMethod === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {
+			// special handling when the server data and the client data before applying the change is the same (after multiple reset changes)
+			// forcefully update the existing server state
+			return false;
+		}
+		return true;
 	};
 
 	return FHIRModel;

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -953,6 +953,10 @@ sap.ui.define([
 		}
 		if (!vServerValue && oRequestInfo.method === HTTPMethod.PUT) {
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
+		} else if (vServerValue && oRequestInfo.method === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {
+			// special handling when the server data and the client changed data is the same(after multiple reset changes)
+			// forcefully update the existing server state
+			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		}
 	};
 
@@ -1525,9 +1529,6 @@ sap.ui.define([
 					this._setProperty(this.oData, FHIRUtils.deepClone(aResPath));
 					this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 					this._removeFromOrderResources(oBindingInfo);
-				}
-				if (Object.keys(this.oDataServerState).length > 0 && this.oDataServerState[aResPath[0]] != undefined && this.oDataServerState[aResPath[0]][aResPath[1]] != undefined) {
-					this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				}
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
 			}.bind(this);

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -954,7 +954,7 @@ sap.ui.define([
 		if (!vServerValue && oRequestInfo.method === HTTPMethod.PUT) {
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		} else if (vServerValue && oRequestInfo.method === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {
-			// special handling when the server data and the client changed data is the same(after multiple reset changes)
+			// special handling when the server data and the client data before applying the change is the same(after multiple reset changes)
 			// forcefully update the existing server state
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		}

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -951,7 +951,7 @@ sap.ui.define([
 		if (sGroupId) {
 			this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath), sGroupId, true);
 		}
-		if (!this._isServerDateUpToDate(vServerValue, oResource, oRequestInfo.method)) {
+		if (!this._isServerStateUpToDate(vServerValue, oResource, oRequestInfo.method)) {
 			this._setProperty(this.oDataServerState, aResPath, FHIRUtils.deepClone(oResource), true);
 		}
 	};
@@ -1612,7 +1612,7 @@ sap.ui.define([
 	 * @private
 	 * @since 2.0.4
 	 */
-	FHIRModel.prototype._isServerDateUpToDate = function(vServerValue, oResource, sHTTPMethod){
+	FHIRModel.prototype._isServerStateUpToDate = function(vServerValue, oResource, sHTTPMethod){
 		if (!vServerValue && sHTTPMethod === HTTPMethod.PUT) {
 			return false;
 		} else if (vServerValue && sHTTPMethod === HTTPMethod.PUT && deepEqual(vServerValue, oResource)) {

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1526,6 +1526,7 @@ sap.ui.define([
 					this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 					this._removeFromOrderResources(oBindingInfo);
 				}
+				this._setProperty(this.oDataServerState, FHIRUtils.deepClone(aResPath));
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
 			}.bind(this);
 			if (sResGroupId === sGroupId){

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -566,6 +566,9 @@ sap.ui.define([
 		this.oFhirModel1.setProperty(this.sPatientPath + "/name/0/given/1", "Peterle");
 		this.oFhirModel1.resetChanges();
 		assert.deepEqual(this.oFhirModel1.oData.Patient[this.sPatientId], oPatient);
+		this.oFhirModel1.setProperty(this.sPatientPath + "/name/0/given/1", "Peterle1");
+		this.oFhirModel1.resetChanges();
+		assert.deepEqual(this.oFhirModel1.oData.Patient[this.sPatientId], oPatient);
 	});
 
 	QUnit.test("reset created/changed resources", function(assert) {


### PR DESCRIPTION
During the second time or any number of times when the reset changes (edit scenario of same resource) is invoked , oDataServerState is not reinitialized properly causing inconsistencies  (actual server state data is lost)
![resetChanges](https://user-images.githubusercontent.com/59359754/100075110-8ac9fd00-2e65-11eb-8837-44ae23138dbe.PNG)
