### PR TITLE
fix: single filter or sorter object

### DIFF
--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -27,8 +27,8 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {string} sPath The binding path in the model
 	 * @param {sap.fhir.model.r4.Context} [oContext] The parent context which is required as base for a relative path
-	 * @param {sap.ui.model.Sorter[]} [aSorters] The dynamic sorters to be used initially
-	 * @param {sap.ui.model.Filter[]} [aFilters] The dynamic application filters to be used initially
+	 * @param {sap.ui.model.Sorter | sap.ui.model.Sorter[]} [aSorters] The dynamic sorters to be used initially (can be either a sorter or an array of sorters)
+	 * @param {sap.ui.model.Filter | sap.ui.model.Filter[]} [aFilters] The dynamic application filters to be used initially (can be either a filter or an array of filters)
 	 * @param {object} [mParameters] The map which contains additional parameters for the binding
 	 * @param {string} [mParameters.groupId] The group id
 	 * @param {sap.fhir.model.r4.OperationMode} [mParameters.operationMode] The operation mode, how to handle operations like filtering and sorting

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -49,8 +49,8 @@ sap.ui.define([
 
 		constructor : function(oModel, sPath, oContext, aSorters, aFilters, mParameters) {
 			ListBinding.apply(this, arguments);
-			this.aFilters = aFilters;
-			this.aSorters = aSorters;
+			this.aFilters = aFilters instanceof Filter ? [aFilters] : aFilters;
+			this.aSorters = aSorters instanceof Sorter ? [aSorters] : aSorters;
 			this.mParameters = mParameters;
 			this.sOperationMode = (mParameters && mParameters.operationMode) || this.oModel.sDefaultOperationMode;
 			if (this.sOperationMode !== OperationMode.Server) {

--- a/src/sap/fhir/model/r4/FHIRTreeBinding.js
+++ b/src/sap/fhir/model/r4/FHIRTreeBinding.js
@@ -23,7 +23,7 @@ sap.ui.define([
 	 * @param {sap.fhir.model.r4.FHIRModel} oModel The FHIRModel
 	 * @param {string} sPath The binding path in the model
 	 * @param {sap.fhir.model.r4.Context} [oContext] The parent context which is required as base for a relative path
-	 * @param {sap.ui.model.Filter[]} [aFilters] The dynamic application filters to be used initially
+	 * @param {sap.ui.model.Filter | sap.ui.model.Filter[]} [aFilters] The dynamic application filters to be used initially (can be either a filter or an array of filters)
 	 * @param {object} [mParameters] The map which contains additional parameters for the binding
 	 * @param {string} [mParameters.groupId] The group id
 	 * @param {sap.fhir.model.r4.OperationMode} [mParameters.operationMode] The operation mode, how to handle operations like filtering and sorting
@@ -35,7 +35,7 @@ sap.ui.define([
 	 * @param {boolean} [mParameters.collapseRecursive=true] Determines if all sub nodes of a single node will be collapsed also, if this single node is collapsed
 	 * @param {number} [mParameters.numberOfExpandedLevels=0] Determines the number of levels, which will be auto-expanded initially
 	 *
-	 * @param {sap.ui.model.Sorter[]} [aSorters] The dynamic sorters to be used initially
+	 * @param {sap.ui.model.Sorter | sap.ui.model.Sorter[]} [aSorters] The dynamic sorters to be used initially (can be either a sorter or an array of sorters)
 	 * @author SAP SE
 	 * @extends sap.ui.model.TreeBinding
 	 * @public

--- a/src/sap/fhir/model/r4/FHIRTreeBinding.js
+++ b/src/sap/fhir/model/r4/FHIRTreeBinding.js
@@ -46,7 +46,8 @@ sap.ui.define([
 
 		constructor : function(oModel, sPath, oContext, aFilters, mParameters, aSorters) {
 			TreeBinding.apply(this, arguments);
-			this.aFilters = aFilters;
+			this.aFilters = aFilters instanceof Filter ? [aFilters] : aFilters;
+			this.aSorters = aSorters instanceof Sorter ? [aSorters] : aSorters;
 			this.aSorters = aSorters;
 			this.sId = FHIRUtils.uuidv4();
 			this._checkParameters(mParameters);

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -8,8 +8,10 @@ sap.ui.define([
 	"sap/fhir/model/r4/FHIRFilterOperator",
 	"sap/ui/model/ChangeReason",
 	"sap/base/util/merge",
-	"sap/base/util/deepEqual"
-], function(FHIRFilterOperatorUtils, FHIRFilterOperator, ChangeReason, merge, deepEqual) {
+	"sap/base/util/deepEqual",
+	"sap/ui/model/Filter",
+	"sap/ui/model/Sorter"
+], function(FHIRFilterOperatorUtils, FHIRFilterOperator, ChangeReason, merge, deepEqual, Filter, Sorter) {
 
 	"use strict";
 
@@ -509,12 +511,18 @@ sap.ui.define([
 	/**
 	 * Filters the actual binding depending on the given <code>aFilters</code>
 	 *
-	 * @param {sap.ui.model.Filter[]} [aFilters] The filters defined for the list binding
+	 * @param {sap.ui.model.Filter | sap.ui.model.Filter[]} [aFilters] The filters defined for the list binding (can be either a filter or an array of filters)
 	 * @param {sap.fhir.model.r4.FHIRListBinding | sap.fhir.model.r4.FHIRTreeBinding} oBinding The binding which triggered the filter
 	 * @public
 	 * @since 1.0.0
 	 */
 	FHIRUtils.filter = function(aFilters, oBinding){
+		if (!aFilters) {
+			aFilters = [];
+		}
+		if (aFilters instanceof Filter) {
+			aFilters = [aFilters];
+		}
 		if (oBinding.bPendingRequest){
 			var fnQueryLastFilters = function() {
 				if (!oBinding.bPendingRequest){
@@ -538,13 +546,19 @@ sap.ui.define([
 	/**
 	 * Sorts the actual list binding based on the given <code>aSorters</code>
 	 *
-	 * @param {sap.ui.model.Sorter[]} aSorters The sorters defined for the list binding
+	 * @param {sap.ui.model.Sorter | sap.ui.model.Sorter[]} aSorters The sorters defined for the list binding (can be either a sorter or an array of sorters)
 	 * @param {sap.fhir.model.r4.FHIRListBinding | sap.fhir.model.r4.FHIRTreeBinding} oBinding The binding which triggered the sort
 	 * @param {boolean} bRefresh If the binding should directly send a call or wait for the filters, for p13ndialog
 	 * @public
 	 * @since 1.0.0
 	 */
 	FHIRUtils.sort = function(aSorters, oBinding, bRefresh){
+		if (!aSorters) {
+			aSorters = [];
+		}
+		if (aSorters instanceof Sorter) {
+			aSorters = [aSorters];
+		}
 		if (oBinding.bPendingRequest){
 			var fnQueryLastSorters = function() {
 				if (!oBinding.bPendingRequest){

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -666,8 +666,13 @@ sap.ui.define([
 		assert.deepEqual(mGoalParameters.birthdate, mParameters.urlParameters.birthdate);
 	});
 
-	QUnit.test("filtering and sorting a list with a single object", function (assert) {
+	QUnit.test("filtering and sorting a list with a single or no object", function (assert) {
 		this.loadDataIntoModel("Patients");
+		this.oListBinding.sort(undefined);
+		this.oListBinding.filter(undefined);
+		assert.deepEqual(this.oListBinding.getFilters(), []);
+		assert.deepEqual(this.oListBinding.getSorters(), []);
+
 		var oGenderFilter = new sap.ui.model.Filter({ path: "gender", operator: FHIRFilterOperator.EQ, value1: "male" });
 		var oSort = new sap.ui.model.Sorter("birthdate", true);
 

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -666,6 +666,23 @@ sap.ui.define([
 		assert.deepEqual(mGoalParameters.birthdate, mParameters.urlParameters.birthdate);
 	});
 
+	QUnit.test("filtering and sorting a list with a single object", function (assert) {
+		this.loadDataIntoModel("Patients");
+		var oGenderFilter = new sap.ui.model.Filter({ path: "gender", operator: FHIRFilterOperator.EQ, value1: "male" });
+		var oSort = new sap.ui.model.Sorter("birthdate", true);
+
+		this.oListBinding.sort(oSort);
+		this.oListBinding.filter(oGenderFilter);
+
+		assert.deepEqual(this.oListBinding.getFilters(), [oGenderFilter]);
+		assert.deepEqual(this.oListBinding.getSorters(), [oSort]);
+
+		var mParameters = this.oListBinding._buildParameters();
+		var mGoalParameters = { "_sort": "-birthdate", "gender:exact": "male" };
+		assert.equal(mGoalParameters["gender:exact"], mParameters.urlParameters["gender:exact"]);
+		assert.equal(mGoalParameters._sort, mParameters.urlParameters._sort);
+	});
+
 	QUnit.test("initial duplicate includes, has chaining and filter", function(assert){
 		var mParameters = this.oListBinding7._buildParameters();
 		var mGoalParameters = {"_include" : ["PractitionerRole:practitioner", "PractitionerRole:organization"], "_has:PractitionerRole:practitioner:organization" : "252", "organization:contains" : "252"};


### PR DESCRIPTION
According to ui5 ListBinding the initial application filters/sorters can be a single or an array https://openui5.hana.ondemand.com/api/sap.ui.model.ListBinding
aFilters? sap.ui.model.Filter|sap.ui.model.Filter[] Predefined filter/s (can be either a filter or an array of filters)
So if a single filter object is given instead of array it doesnt get applied since the model expects an array as default. This fix ensures to convert single instance of filter to an array of filters before applying it to the corresponding binding. oData ListBinding also handles it in the same way
<img width="1401" alt="Screenshot 2021-03-09 at 7 46 15 PM" src="https://user-images.githubusercontent.com/59359754/110483976-3f83e380-8110-11eb-89c1-e48e3a4b5e03.png">
