### PR TITLE
feat: Implement the support for _filter

### DIFF
--- a/docs/tutorials/3 Advanced Bindings.md
+++ b/docs/tutorials/3 Advanced Bindings.md
@@ -255,13 +255,15 @@ oBinding.filter(
 
 #### 2. Complex Filtering
 FHIR® specifies the use of `_filter` search expression parameter to support complex combination queries.
-To ensure complex filtering support is enabled the model is initialised with `simpleFiltering:false` property
+To ensure complex filtering support is enabled the model is initialised with `filtering: {complex: true}` property
 ```json
 "": {
 	"type": "sap.fhir.model.r4.FHIRModel",
 	"dataSource": "fhir",
         "settings":{
-          "simpleFiltering": false
+           "filtering": {
+			  "complex": true
+		   }
          }            
 }
 ```

--- a/docs/tutorials/3 Advanced Bindings.md
+++ b/docs/tutorials/3 Advanced Bindings.md
@@ -221,6 +221,7 @@ A FHIR® operation can also return a collection of versions of a specific FHIR®
 
 ### Step 3.9 Filtering in FHIR® Resources
 `sap.fhir.model.r4.FHIRFilter`, which extends `sap.ui.model.Filter`, and necessary helper classes support the special syntax that the FHIR® query language uses because of the different search parameter data types. 
+
 #### 1. Simple Filtering
 For more information regarding simple filtering and the operators to be used refer the following [FHIR®-Specific Filters](https://www.hl7.org/fhir/search.html#prefix) and [FHIR®- SearchModifiers](https://www.hl7.org/fhir/search.html#modifiers). The following example shows how these classes are used.
 
@@ -251,8 +252,9 @@ oBinding.filter(
 	]
 );
 ```
+
 #### 2. Complex Filtering
-FHIR specifies the use of `_filter` search expression parameter to support complex combination queries.
+FHIR® specifies the use of `_filter` search expression parameter to support complex combination queries.
 To ensure complex filtering support is enabled the model is initialised with `simpleFiltering:false` property
 ```json
 "": {
@@ -264,15 +266,15 @@ To ensure complex filtering support is enabled the model is initialised with `si
 }
 ```
 For more information regarding `_filter` refer the following [FHIR® Filters](https://www.hl7.org/fhir/search_filter.html).
-Its necessary to initialise the filter with valueType as "string" if the value is of type string. This is to ensure that the value is encoded with "".
+It's necessary to initialise the filter with valueType as "string" if the value is of type string. This is to ensure that the value is encoded with "".
 
-*Example: Find all patients whose names are either Habibi or Damon 
+*Example: Find all patients whose names are either "Habibi" or "Damon" 
 `( name eq "Habibi" or name eq "Damon" )`* 
 ```javascript
 
 sap.ui.define([ ...
 	"sap/ui/model/Filter",
-	"sap/fhir/model/r4/FHIRFilter"
+	"sap/fhir/model/r4/FHIRFilter",
 	"sap/fhir/model/r4/FHIRFilterOperator",
 	"sap/fhir/model/r4/FHIRFilterType",
 	...
@@ -292,23 +294,24 @@ oBinding.filter(
 			valueType : FHIRFilterType.string,
 			value1: "Damon"
 		})
-	],false
+	], false
 );
 ```
-*Example: Find all patients whose names starts with either Da and ends with on and whose birthdate is 25-12-1987 `( ( name sw "Da" and name ew "on" ) and birthdate eq 1987-12-25 )`* 
+*Example: Find all patients whose names starts with either "Da" and ends with "on" and whose birthdate is 25-12-1987 `( ( name sw "Da" and name ew "on" ) and birthdate eq 1987-12-25 )`* 
 ```javascript
 
-sap.ui.define([ ...
-	"sap/ui/model/Filter",
-	"sap/fhir/model/r4/FHIRFilter"
-	"sap/fhir/model/r4/FHIRFilterOperator",
-	"sap/fhir/model/r4/FHIRFilterType",
-	...
+sap.ui.define([...
+    "sap/ui/model/Filter",
+    "sap/fhir/model/r4/FHIRFilter",
+    "sap/fhir/model/r4/FHIRFilterComplexOperator",
+    "sap/fhir/model/r4/FHIRFilterType",
+...
 ]
 ...
-var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.StartsWith, value1: "Da", valueType: FHIRFilterType.string });
-var oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "on", valueType: FHIRFilterType.string });
+var oNameFilter = new FHIRFilter({ path: "name", operator: FHIRFilterComplexOperator.StartsWith, value1: "Da", valueType: FHIRFilterType.string });
+var oNameFilter1 = new FHIRFilter({ path: "name", operator: FHIRFilterComplexOperator.EndsWith, value1: "on", valueType: FHIRFilterType.string });
 var oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);
-var oBirthDateFilter = 	new FHIRFilter({ path: "birthdate", operator: FilterOperator.EQ, value1: "1987-12-25"});
-oBinding.filter([oCombinedFilter,oBirthDateFilter],true);
+var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FHIRFilterComplexOperator.EQ, value1: "1987-12-25" });
+oBinding.filter([oCombinedFilter, oBirthDateFilter], true);
+
 ```

--- a/docs/tutorials/3 Advanced Bindings.md
+++ b/docs/tutorials/3 Advanced Bindings.md
@@ -220,8 +220,9 @@ A FHIR® operation can also return a collection of versions of a specific FHIR®
 ```
 
 ### Step 3.9 Filtering in FHIR® Resources
-`sap.fhir.model.r4.FHIRFilter`, which extends `sap.ui.model.Filter`, and necessary helper classes support the special syntax that the FHIR® query language uses because of the different search parameter data types. The following example shows how these classes are used.
-For more information refer the following [FHIR®-Specific Filters](https://www.hl7.org/fhir/search.html#prefix) and [FHIR®- SearchModifiers](https://www.hl7.org/fhir/search.html#modifiers).
+`sap.fhir.model.r4.FHIRFilter`, which extends `sap.ui.model.Filter`, and necessary helper classes support the special syntax that the FHIR® query language uses because of the different search parameter data types. 
+#### 1. Simple Filtering
+For more information regarding simple filtering and the operators to be used refer the following [FHIR®-Specific Filters](https://www.hl7.org/fhir/search.html#prefix) and [FHIR®- SearchModifiers](https://www.hl7.org/fhir/search.html#modifiers). The following example shows how these classes are used.
 
 *Example: Filtering a Binding with FHIR®-Specific Filters and SearchModifier :missing* 
 ```javascript
@@ -249,4 +250,65 @@ oBinding.filter(
 		})
 	]
 );
+```
+#### 2. Complex Filtering
+FHIR specifies the use of `_filter` search expression parameter to support complex combination queries.
+To ensure complex filtering support is enabled the model is initialised with `simpleFiltering:false` property
+```json
+"": {
+	"type": "sap.fhir.model.r4.FHIRModel",
+	"dataSource": "fhir",
+    "settings":{
+      "simpleFiltering": false
+   }            
+}
+```
+For more information regarding `_filter` refer the following [FHIR® Filters](https://www.hl7.org/fhir/search_filter.html).
+Its necessary to initialise the filter with valueType as "string" if the value is of type string. This is to ensure that the value is encoded with "".
+
+*Example: Find all patients whose names are either Habibi or Damon 
+`( name eq "Habibi" or name eq "Damon" )`* 
+```javascript
+
+sap.ui.define([ ...
+	"sap/ui/model/Filter",
+	"sap/fhir/model/r4/FHIRFilter"
+	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterType",
+	...
+]
+...
+oBinding.filter(
+	[
+		new FHIRFilter({
+			path : "name",
+			operator : FHIRFilterOperator.EQ,
+			valueType : FHIRFilterType.string,
+			value1: "Habibi"
+		}),
+		new Filter({
+			path : "name",
+			operator : FHIRFilterOperator.EQ,
+			valueType : FHIRFilterType.string,
+			value1: "Damon"
+		})
+	],false
+);
+```
+*Example: Find all patients whose names starts with either Da and ends with on and whose birthdate is 25-12-1987 `( ( name sw "Da" and name ew "on" ) and birthdate eq 1987-12-25 )`* 
+```javascript
+
+sap.ui.define([ ...
+	"sap/ui/model/Filter",
+	"sap/fhir/model/r4/FHIRFilter"
+	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterType",
+	...
+]
+...
+var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.StartsWith, value1: "Da", valueType: FHIRFilterType.string });
+var	oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "on", valueType: FHIRFilterType.string });
+var	oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);
+var oBirthDateFilter = 	new FHIRFilter({ path: "birthdate", operator: FilterOperator.EQ, value1: "1987-12-25"});
+oBinding.filter([oCombinedFilter,oBirthDateFilter],true);
 ```

--- a/docs/tutorials/3 Advanced Bindings.md
+++ b/docs/tutorials/3 Advanced Bindings.md
@@ -307,8 +307,8 @@ sap.ui.define([ ...
 ]
 ...
 var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.StartsWith, value1: "Da", valueType: FHIRFilterType.string });
-var	oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "on", valueType: FHIRFilterType.string });
-var	oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);
+var oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "on", valueType: FHIRFilterType.string });
+var oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);
 var oBirthDateFilter = 	new FHIRFilter({ path: "birthdate", operator: FilterOperator.EQ, value1: "1987-12-25"});
 oBinding.filter([oCombinedFilter,oBirthDateFilter],true);
 ```

--- a/docs/tutorials/3 Advanced Bindings.md
+++ b/docs/tutorials/3 Advanced Bindings.md
@@ -258,9 +258,9 @@ To ensure complex filtering support is enabled the model is initialised with `si
 "": {
 	"type": "sap.fhir.model.r4.FHIRModel",
 	"dataSource": "fhir",
-    "settings":{
-      "simpleFiltering": false
-   }            
+        "settings":{
+          "simpleFiltering": false
+         }            
 }
 ```
 For more information regarding `_filter` refer the following [FHIR® Filters](https://www.hl7.org/fhir/search_filter.html).

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "npm": ">= 5"
   },
   "devDependencies": {
-    "eslint": "^7.21.0",
+    "eslint": "^7.22.0",
     "eslint-watch": "^7.0.0",
     "js-beautify": "^1.13.5",
     "jsdoc": "^3.6.6",

--- a/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
+++ b/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
@@ -1,0 +1,65 @@
+/*!
+ * ${copyright}
+ */
+
+// Provides class sap.fhir.model.r4.FHIRFilterComplexOperator
+sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator"], function (FHIRFilterOperator) {
+
+	"use strict";
+
+	/**
+	 * Operators for the FHIR Complex Filter. Documentation https://www.hl7.org/fhir/search_filter.html#ops
+	 *
+	 * @enum {string}
+	 * @public
+	 * @alias sap.fhir.model.r4.FHIRFilterComplexOperator
+	 * @extends sap.ui.model.FHIRFilterOperator
+	 */
+	var FHIRFilterComplexOperator = {
+		/**
+		 * The set is empty or not (value is false or true)
+		 *
+		 * @public
+		 */
+		PR: "pr",
+		/**
+		 * If a (implied) date period in the set overlaps with the implied period in the value
+		 *
+		 * @public
+		 */
+		PO: "po",
+		/**
+		 * If the value subsumes a concept in the set
+		 *
+		 * @public
+		 */
+		SS: "ss",
+		/**
+		 * If the value is subsumed by a concept in the set
+		 *
+		 * @public
+		 */
+		SB: "sb",
+		/**
+		 * If one of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
+		 *
+		 * @public
+		 */
+		IN: "in",
+		/**
+		 * If none of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
+		 *
+		 * @public
+		 */
+		NI: "ni",
+		/**
+		 * If one of the references in set points to the given URL
+		 *
+		 * @public
+		 */
+		RE: "re"
+	};
+
+	// merge the FHIR FilterOperator object into the FHIRFilterComplexOperator
+	return Object.assign(FHIRFilterComplexOperator, FHIRFilterOperator);
+});

--- a/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
+++ b/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
@@ -22,36 +22,42 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator"], function (FHIRFilterOper
 		 * @public
 		 */
 		PR: "pr",
+
 		/**
 		 * If a (implied) date period in the set overlaps with the implied period in the value
 		 *
 		 * @public
 		 */
 		PO: "po",
+
 		/**
 		 * If the value subsumes a concept in the set
 		 *
 		 * @public
 		 */
 		SS: "ss",
+
 		/**
 		 * If the value is subsumed by a concept in the set
 		 *
 		 * @public
 		 */
 		SB: "sb",
+
 		/**
 		 * If one of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
 		 *
 		 * @public
 		 */
 		IN: "in",
+
 		/**
 		 * If none of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
 		 *
 		 * @public
 		 */
 		NI: "ni",
+		
 		/**
 		 * If one of the references in set points to the given URL
 		 *

--- a/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
+++ b/src/sap/fhir/model/r4/FHIRFilterComplexOperator.js
@@ -57,7 +57,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator"], function (FHIRFilterOper
 		 * @public
 		 */
 		NI: "ni",
-		
+
 		/**
 		 * If one of the references in set points to the given URL
 		 *

--- a/src/sap/fhir/model/r4/FHIRFilterOperator.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperator.js
@@ -21,7 +21,7 @@ sap.ui.define(["sap/ui/model/FilterOperator"], function(FilterOperator) {
 		 *
 		 * @public
 		 */
-		Missing : "Missing",
+		Missing: "Missing",
 		/**
 		 * starts-after
 		 * e.g.: sa2013-03-14
@@ -41,7 +41,49 @@ sap.ui.define(["sap/ui/model/FilterOperator"], function(FilterOperator) {
 		 *
 		 * @public
 		 */
-		AP: "ap"
+		AP: "ap",
+		/**
+		 * The set is empty or not (value is false or true)
+		 *
+		 * @public
+		 */
+		PR: "pr",
+		/**
+		 * if a (implied) date period in the set overlaps with the implied period in the value
+		 *
+		 * @public
+		 */
+		PO: "po",
+		/**
+		 * if the value subsumes a concept in the set
+		 *
+		 * @public
+		 */
+		SS: "ss",
+		/**
+		 * if the value is subsumed by a concept in the set
+		 *
+		 * @public
+		 */
+		SB: "sb",
+		/**
+		 * if one of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
+		 *
+		 * @public
+		 */
+		IN: "in",
+		/**
+		 * if none of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
+		 *
+		 * @public
+		 */
+		NI: "ni",
+		/**
+		 * if one of the references in set points to the given URL
+		 *
+		 * @public
+		 */
+		RE: "re"
 	};
 
 	// merge the UI5 FilterOperator object into the FHIRFilterOperator

--- a/src/sap/fhir/model/r4/FHIRFilterOperator.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperator.js
@@ -3,7 +3,7 @@
  */
 
 // Provides class sap.fhir.model.r4.FHIRFilterOperator
-sap.ui.define(["sap/ui/model/FilterOperator"], function(FilterOperator) {
+sap.ui.define(["sap/ui/model/FilterOperator"], function (FilterOperator) {
 
 	"use strict";
 
@@ -41,49 +41,7 @@ sap.ui.define(["sap/ui/model/FilterOperator"], function(FilterOperator) {
 		 *
 		 * @public
 		 */
-		AP: "ap",
-		/**
-		 * The set is empty or not (value is false or true)
-		 *
-		 * @public
-		 */
-		PR: "pr",
-		/**
-		 * if a (implied) date period in the set overlaps with the implied period in the value
-		 *
-		 * @public
-		 */
-		PO: "po",
-		/**
-		 * if the value subsumes a concept in the set
-		 *
-		 * @public
-		 */
-		SS: "ss",
-		/**
-		 * if the value is subsumed by a concept in the set
-		 *
-		 * @public
-		 */
-		SB: "sb",
-		/**
-		 * if one of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
-		 *
-		 * @public
-		 */
-		IN: "in",
-		/**
-		 * if none of the concepts is in the nominated value set by URI, either a relative, literal or logical vs
-		 *
-		 * @public
-		 */
-		NI: "ni",
-		/**
-		 * if one of the references in set points to the given URL
-		 *
-		 * @public
-		 */
-		RE: "re"
+		AP: "ap"
 	};
 
 	// merge the UI5 FilterOperator object into the FHIRFilterOperator

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -84,7 +84,7 @@ sap.ui.define([
 	 *
 	 * @param {any} oValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
-	 * @protected
+	 * @public
 	 * @since 1.0.0
 	 */
 	FHIRFilterOperatorUtils.getFilterValue = function (oValue) {
@@ -221,7 +221,7 @@ sap.ui.define([
 	 * @param {string} sFilterValue The value type of a filter object
 	 * @param {any} vValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
-	 * @protected
+	 * @public
 	 * @since 2.1.0
 	 */
 	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, vValue) {

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -80,7 +80,7 @@ sap.ui.define([
 	};
 
 	/**
-	 * Parses the JS filter value to an FHIR filter value
+	 * Parses the JS filter value to a FHIR filter value
 	 *
 	 * @param {any} oValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
@@ -96,7 +96,7 @@ sap.ui.define([
 	};
 
 	/**
-	 * Transforms the UI5 filter operator to an FHIR valid search prefix based on the given UI5 <code>oFilter</code>
+	 * Transforms the UI5 filter operator to a FHIR valid search prefix based on the given UI5 <code>oFilter</code>
 	 *
 	 * @param {sap.ui.model.Filter} oFilter The given filter
 	 * @returns {string} The date FHIR search prefix
@@ -216,7 +216,7 @@ sap.ui.define([
 	};
 
 	/**
-	 * Parses the JS filter value to an FHIR filter value
+	 * Parses the JS filter value to a FHIR filter value
 	 *
 	 * @param {string} sFilterValue The value type of a filter object
 	 * @param {any} vValue The value of a filter object

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -206,7 +206,6 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 				sFHIRFilterPrefix = "re";
 				break;
 			default:
-				sFHIRFilterPrefix = oFilter.sOperator.toLowerCase();
 				break;
 		}
 		return sFHIRFilterPrefix;

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -138,6 +138,81 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	};
 
 	/**
+	 * Transforms the UI5 filter operator to an FHIR valid filter prefix based on the given UI5 <code>oFilter</code>
+	 *
+	 * @param {sap.ui.model.Filter} oFilter The given filter
+	 * @returns {string} The FHIR filter prefix
+	 * @protected
+	 * @since 2.1.0
+	 */
+	FHIRFilterOperatorUtils.getFHIRFilterPrefix = function (oFilter) {
+		var sFHIRFilterPrefix;
+		switch (oFilter.sOperator) {
+			case FHIRFilterOperator.EQ:
+				sFHIRFilterPrefix = "eq";
+				break;
+			case FHIRFilterOperator.NE:
+				sFHIRFilterPrefix = "ne";
+				break;
+			case FHIRFilterOperator.GT:
+				sFHIRFilterPrefix = "gt";
+				break;
+			case FHIRFilterOperator.GE:
+				sFHIRFilterPrefix = "ge";
+				break;
+			case FHIRFilterOperator.LT:
+				sFHIRFilterPrefix = "lt";
+				break;
+			case FHIRFilterOperator.LE:
+				sFHIRFilterPrefix = "le";
+				break;
+			case FHIRFilterOperator.SA:
+				sFHIRFilterPrefix = "sa";
+				break;
+			case FHIRFilterOperator.EB:
+				sFHIRFilterPrefix = "eb";
+				break;
+			case FHIRFilterOperator.AP:
+				sFHIRFilterPrefix = "ap";
+				break;
+			case FHIRFilterOperator.StartsWith:
+				sFHIRFilterPrefix = "sw";
+				break;
+			case FHIRFilterOperator.EndsWith:
+				sFHIRFilterPrefix = "ew";
+				break;
+			case FHIRFilterOperator.Contains:
+				sFHIRFilterPrefix = "co";
+				break;
+			case FHIRFilterOperator.PR:
+				sFHIRFilterPrefix = "pr";
+				break;
+			case FHIRFilterOperator.PO:
+				sFHIRFilterPrefix = "po";
+				break;
+			case FHIRFilterOperator.SS:
+				sFHIRFilterPrefix = "ss";
+				break;
+			case FHIRFilterOperator.SB:
+				sFHIRFilterPrefix = "sb";
+				break;
+			case FHIRFilterOperator.IN:
+				sFHIRFilterPrefix = "in";
+				break;
+			case FHIRFilterOperator.NI:
+				sFHIRFilterPrefix = "ni";
+				break;
+			case FHIRFilterOperator.RE:
+				sFHIRFilterPrefix = "re";
+				break;
+			default:
+				sFHIRFilterPrefix = oFilter.sOperator.toLowerCase();
+				break;
+		}
+		return sFHIRFilterPrefix;
+	};
+
+	/**
 	 * Parses the JS filter value to an FHIR filter value
 	 *
 	 * @param {string} sFilterValue The value type of a filter object
@@ -152,7 +227,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 		if (isStringFilterType) {
 			// special handling for string parameter as per fhir
 			// given eq "peter"
-			sValue = '"' + oValue + '"';
+			sValue = "\"" + oValue + "\"";
 		} else {
 			sValue = oValue;
 		}

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -84,7 +84,7 @@ sap.ui.define([
 	 *
 	 * @param {any} oValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
-	 * @public
+	 * @protected
 	 * @since 1.0.0
 	 */
 	FHIRFilterOperatorUtils.getFilterValue = function (oValue) {
@@ -219,7 +219,7 @@ sap.ui.define([
 	 * Parses the JS filter value to an FHIR filter value
 	 *
 	 * @param {string} sFilterValue The value type of a filter object
-	 * @param {string} oValue The value type of a filter object
+	 * @param {any} oValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
 	 * @protected
 	 * @since 2.1.0

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -137,5 +137,27 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 		return sFHIRSearchPrefix;
 	};
 
+	/**
+	 * Parses the JS filter value to an FHIR filter value
+	 *
+	 * @param {string} sFilterValue The value type of a filter object
+	 * @param {string} oValue The value type of a filter object
+	 * @returns {string} Formatted FHIR filter value
+	 * @public
+	 * @since 2.1.0
+	 */
+	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, oValue) {
+		var isStringFilterType = sFilterValue && sFilterValue === FHIRFilterType.string ? true : false;
+		var sValue;
+		if (isStringFilterType) {
+			// special handling for string parameter as per fhir
+			// given eq "peter"
+			sValue = '"' + oValue + '"';
+		} else {
+			sValue = oValue;
+		}
+		return sValue;
+	};
+
 	return FHIRFilterOperatorUtils;
 });

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -219,20 +219,20 @@ sap.ui.define([
 	 * Parses the JS filter value to an FHIR filter value
 	 *
 	 * @param {string} sFilterValue The value type of a filter object
-	 * @param {any} oValue The value of a filter object
+	 * @param {any} vValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
 	 * @protected
 	 * @since 2.1.0
 	 */
-	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, oValue) {
+	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, vValue) {
 		var isStringFilterType = sFilterValue && sFilterValue === FHIRFilterType.string ? true : false;
 		var sValue;
 		if (isStringFilterType) {
 			// special handling for string parameter as per fhir
 			// given eq "peter"
-			sValue = "\"" + oValue + "\"";
+			sValue = "\"" + vValue + "\"";
 		} else {
-			sValue = oValue;
+			sValue = vValue;
 		}
 		return sValue;
 	};

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -3,7 +3,11 @@
  */
 
 // Provides class sap.fhir.model.r4.FHIRFilterOperatorUtils
-sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFilterType"], function(FHIRFilterOperator, FHIRFilterType) {
+sap.ui.define([
+	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterType",
+	"sap/fhir/model/r4/FHIRFilterComplexOperator"
+], function (FHIRFilterOperator, FHIRFilterType, FHIRFilterComplexOperator) {
 
 	"use strict";
 
@@ -28,7 +32,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRFilterOperatorUtils.getFHIRSearchParameterModifier = function(oFilter) {
+	FHIRFilterOperatorUtils.getFHIRSearchParameterModifier = function (oFilter) {
 		var sFHIRSearchModifier = "";
 		if (this.isSearchParameterModifiable(oFilter) || FHIRFilterOperator.Missing === oFilter.sOperator) {
 			switch (oFilter.sOperator) {
@@ -59,7 +63,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRFilterOperatorUtils.isSearchParameterModifiable = function(oFilter) {
+	FHIRFilterOperatorUtils.isSearchParameterModifiable = function (oFilter) {
 		return oFilter.sValueType !== FHIRFilterType.date && oFilter.sValueType !== FHIRFilterType.number && (typeof oFilter.oValue1 === "string" || Array.isArray(oFilter.oValue1));
 	};
 
@@ -71,7 +75,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRFilterOperatorUtils.isSearchParameterPrefixable = function(oFilter) {
+	FHIRFilterOperatorUtils.isSearchParameterPrefixable = function (oFilter) {
 		return !(typeof oFilter.oValue1 === "string" || Array.isArray(oFilter.oValue1)) || oFilter.sValueType === FHIRFilterType.date || !isNaN(oFilter.oValue1);
 	};
 
@@ -83,7 +87,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRFilterOperatorUtils.getFilterValue = function(oValue) {
+	FHIRFilterOperatorUtils.getFilterValue = function (oValue) {
 		var sValue = oValue;
 		if (oValue instanceof Date) {
 			sValue = oValue.toISOString();
@@ -99,7 +103,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRFilterOperatorUtils.getFHIRSearchPrefix = function(oFilter) {
+	FHIRFilterOperatorUtils.getFHIRSearchPrefix = function (oFilter) {
 		var sFHIRSearchPrefix;
 		if (this.isSearchParameterPrefixable(oFilter)) {
 			switch (oFilter.sOperator) {
@@ -138,7 +142,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	};
 
 	/**
-	 * Transforms the UI5 filter operator to an FHIR valid filter prefix based on the given UI5 <code>oFilter</code>
+	 * Transforms the UI5 filter operator to a FHIR valid filter prefix based on the given UI5 <code>oFilter</code>
 	 *
 	 * @param {sap.ui.model.Filter} oFilter The given filter
 	 * @returns {string} The FHIR filter prefix
@@ -148,61 +152,61 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	FHIRFilterOperatorUtils.getFHIRFilterPrefix = function (oFilter) {
 		var sFHIRFilterPrefix;
 		switch (oFilter.sOperator) {
-			case FHIRFilterOperator.EQ:
+			case FHIRFilterComplexOperator.EQ:
 				sFHIRFilterPrefix = "eq";
 				break;
-			case FHIRFilterOperator.NE:
+			case FHIRFilterComplexOperator.NE:
 				sFHIRFilterPrefix = "ne";
 				break;
-			case FHIRFilterOperator.GT:
+			case FHIRFilterComplexOperator.GT:
 				sFHIRFilterPrefix = "gt";
 				break;
-			case FHIRFilterOperator.GE:
+			case FHIRFilterComplexOperator.GE:
 				sFHIRFilterPrefix = "ge";
 				break;
-			case FHIRFilterOperator.LT:
+			case FHIRFilterComplexOperator.LT:
 				sFHIRFilterPrefix = "lt";
 				break;
-			case FHIRFilterOperator.LE:
+			case FHIRFilterComplexOperator.LE:
 				sFHIRFilterPrefix = "le";
 				break;
-			case FHIRFilterOperator.SA:
+			case FHIRFilterComplexOperator.SA:
 				sFHIRFilterPrefix = "sa";
 				break;
-			case FHIRFilterOperator.EB:
+			case FHIRFilterComplexOperator.EB:
 				sFHIRFilterPrefix = "eb";
 				break;
-			case FHIRFilterOperator.AP:
+			case FHIRFilterComplexOperator.AP:
 				sFHIRFilterPrefix = "ap";
 				break;
-			case FHIRFilterOperator.StartsWith:
+			case FHIRFilterComplexOperator.StartsWith:
 				sFHIRFilterPrefix = "sw";
 				break;
-			case FHIRFilterOperator.EndsWith:
+			case FHIRFilterComplexOperator.EndsWith:
 				sFHIRFilterPrefix = "ew";
 				break;
-			case FHIRFilterOperator.Contains:
+			case FHIRFilterComplexOperator.Contains:
 				sFHIRFilterPrefix = "co";
 				break;
-			case FHIRFilterOperator.PR:
+			case FHIRFilterComplexOperator.PR:
 				sFHIRFilterPrefix = "pr";
 				break;
-			case FHIRFilterOperator.PO:
+			case FHIRFilterComplexOperator.PO:
 				sFHIRFilterPrefix = "po";
 				break;
-			case FHIRFilterOperator.SS:
+			case FHIRFilterComplexOperator.SS:
 				sFHIRFilterPrefix = "ss";
 				break;
-			case FHIRFilterOperator.SB:
+			case FHIRFilterComplexOperator.SB:
 				sFHIRFilterPrefix = "sb";
 				break;
-			case FHIRFilterOperator.IN:
+			case FHIRFilterComplexOperator.IN:
 				sFHIRFilterPrefix = "in";
 				break;
-			case FHIRFilterOperator.NI:
+			case FHIRFilterComplexOperator.NI:
 				sFHIRFilterPrefix = "ni";
 				break;
-			case FHIRFilterOperator.RE:
+			case FHIRFilterComplexOperator.RE:
 				sFHIRFilterPrefix = "re";
 				break;
 			default:
@@ -217,7 +221,7 @@ sap.ui.define(["sap/fhir/model/r4/FHIRFilterOperator", "sap/fhir/model/r4/FHIRFi
 	 * @param {string} sFilterValue The value type of a filter object
 	 * @param {string} oValue The value type of a filter object
 	 * @returns {string} Formatted FHIR filter value
-	 * @public
+	 * @protected
 	 * @since 2.1.0
 	 */
 	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, oValue) {

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -90,7 +90,7 @@ sap.ui.define([
 			this.oDefaultUri = this.sDefaultFullUrlType === "url" ? new Url() : new Uuid();
 			this.iSizeLimit = 10;
 			if (mParameters && mParameters.simpleFiltering === false){
-				throw new Error("Complex filtering not supported");
+				this.iSupportedFilterDepth = undefined;
 			} else {
 				this.iSupportedFilterDepth = 2;
 			}

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -62,6 +62,7 @@ sap.ui.define([
 	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed on resource type specific requests and not resource instance specific requests (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {boolean} [mParameters.x-csrf-token=false] The model handles the csrf token between the browser and the FHIR server
+	 * @param {object} [mParameters.filtering={complex:false}] The default filtering type. If complex is true all search parameters would be modelled via _filter [https://www.hl7.org/fhir/search_filter.html]
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
 	 * @author SAP SE
 	 * @public
@@ -89,7 +90,7 @@ sap.ui.define([
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";
 			this.oDefaultUri = this.sDefaultFullUrlType === "url" ? new Url() : new Uuid();
 			this.iSizeLimit = 10;
-			if (mParameters && mParameters.simpleFiltering === false){
+			if (mParameters && mParameters.filtering && mParameters.filtering.complex === true){
 				this.iSupportedFilterDepth = undefined;
 			} else {
 				this.iSupportedFilterDepth = 2;

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -62,7 +62,8 @@ sap.ui.define([
 	 * @param {object} [mParameters.defaultQueryParameters={}] The default query parameters to be passed on resource type specific requests and not resource instance specific requests (e.g /Patient?_total:accurate&_format:json). It should be of type key:value pairs. e.g. {'_total':'accurate'} -> http://hl7.org/fhir/http.html#parameters
 	 * @param {string} [mParameters.Prefer='return=minimal'] The FHIR server won't return the changed resource by an POST/PUT request -> https://www.hl7.org/fhir/http.html#2.21.0.5.2
 	 * @param {boolean} [mParameters.x-csrf-token=false] The model handles the csrf token between the browser and the FHIR server
-	 * @param {object} [mParameters.filtering={complex:false}] The default filtering type. If complex is true all search parameters would be modelled via _filter [https://www.hl7.org/fhir/search_filter.html]
+	 * @param {object} [mParameters.filtering={}] The filtering options
+	 * @param {boolean} [mParameters.filtering.complex=false}] The default filtering type. If <code>true</code>, all search parameters would be modelled via {@link https://www.hl7.org/fhir/search_filter.html _filter}
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
 	 * @author SAP SE
 	 * @public

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -549,11 +549,7 @@ sap.ui.define([
 				var sFilter;
 				if (oFilter.sOperator === FHIRFilterOperator.BT) {
 					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
-					sFilter = " ( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " ) ";
-				} else if (oFilter.bAnd != undefined) {
-					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
-					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
-					sFilter = " ( " + sPath + " ge " + oValue1 + sLogicalConnection1 + sPath + " le " + oValue2 + " ) ";
+					sFilter = "( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " )";
 				} else {
 					sFilter = sPath + " " + sFilterOperator + " " + oValue1;
 				}

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -527,9 +527,7 @@ sap.ui.define([
 		if (oFilter instanceof Filter) {
 			if (oFilter._bMultiFilter) {
 				// recursive
-				if (oFilter.bAnd != undefined) {
-					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
-				}
+				sLogicalConnection1 = oFilter.bAnd && oFilter.bAnd == true ? " and " : " or ";
 				if (oFilter.aFilters) {
 					mParameters._filter = mParameters._filter + "( ";
 					// for the first filter the logical connection shouldnt be appended

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -502,7 +502,7 @@ sap.ui.define([
 			mParameters.filter = oFilter.oValue1;
 		} else if (oFilter.sOperator === FHIRFilterOperator.BT) {
 			var oValue2 = FHIRFilterOperatorUtils.getFilterValue(oFilter.oValue2);
-			mParameters[sPath + sFhirSearchModifier] = ["ge" + oValue1, "le" + oValue2];
+			mParameters[sPath + sFhirSearchModifier] = [FHIRFilterOperator.GE.toLowerCase() + oValue1, FHIRFilterOperator.LE.toLowerCase() + oValue2];
 		} else if (bLogicalConnection && !bLogicalOperator) {
 			if (mParameters[sPath + sFhirSearchModifier]) {
 				mParameters[sPath + sFhirSearchModifier].push(vValue);
@@ -517,7 +517,7 @@ sap.ui.define([
 	/**
 	 * Creates a complex filter
 	 *
-	 * @param {object} oFilter The filter which should be added to the parameters
+	 * @param {sap.ui.model.Filter} oFilter The filter which should be added to the parameters
 	 * @param {object} mParameters The parameters which should be passed to the request
 	 * @param {string} [sLogicalConnection] if the list of filters needs to be combined either with AND or OR
 	 * @private
@@ -528,7 +528,7 @@ sap.ui.define([
 		if (oFilter instanceof Filter) {
 			if (oFilter._bMultiFilter) {
 				// recursive
-				sLogicalConnection1 = oFilter.bAnd && oFilter.bAnd == true ? " and " : " or ";
+				sLogicalConnection1 = oFilter.bAnd && oFilter.bAnd == true ? "and" : "or";
 				if (oFilter.aFilters) {
 					mParameters._filter = mParameters._filter + "( ";
 					// for the first filter the logical connection shouldnt be appended
@@ -548,12 +548,12 @@ sap.ui.define([
 				var sFilter;
 				if (oFilter.sOperator === FHIRFilterComplexOperator.BT) {
 					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
-					sFilter = "( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " )";
+					sFilter = "( " + sPath + " " + FHIRFilterComplexOperator.GE.toLowerCase() + " " + oValue1 + " and " + sPath + " " + FHIRFilterComplexOperator.LE.toLowerCase() + " " + oValue2 + " )";
 				} else {
 					sFilter = sPath + " " + sFilterOperator + " " + oValue1;
 				}
 				if (sLogicalConnection) {
-					mParameters._filter = mParameters._filter + sLogicalConnection + sFilter;
+					mParameters._filter = mParameters._filter + " " + sLogicalConnection + " " + sFilter;
 				} else {
 					mParameters._filter = mParameters._filter + sFilter;
 				}

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -519,7 +519,7 @@ sap.ui.define([
 	 *
 	 * @param {object} oFilter The filter which should be added to the parameters
 	 * @param {object} mParameters The parameters which should be passed to the request
-	 * @param {string} sLogicalConnection if the list of filters needs to be combined either with AND or OR
+	 * @param {string} [sLogicalConnection] if the list of filters needs to be combined either with AND or OR
 	 * @private
 	 * @since 2.1.0
 	 */

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -545,11 +545,13 @@ sap.ui.define([
 				var sPath = oFilter.sPath;
 				var sFilterOperator = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 				var oValue1 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue1);
-				var oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
+				var oValue2;
 				var sFilter;
 				if (oFilter.sOperator === FHIRFilterOperator.BT) {
+					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
 					sFilter = " ( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " ) ";
 				} else if (oFilter.bAnd != undefined) {
+					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
 					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
 					sFilter = " ( " + sPath + " ge " + oValue1 + sLogicalConnection1 + sPath + " le " + oValue2 + " ) ";
 				} else {

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -6,12 +6,13 @@
 sap.ui.define([
 	"sap/fhir/model/r4/FHIRFilterOperatorUtils",
 	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterComplexOperator",
 	"sap/ui/model/ChangeReason",
 	"sap/base/util/merge",
 	"sap/base/util/deepEqual",
 	"sap/ui/model/Filter",
 	"sap/ui/model/Sorter"
-], function(FHIRFilterOperatorUtils, FHIRFilterOperator, ChangeReason, merge, deepEqual, Filter, Sorter) {
+], function (FHIRFilterOperatorUtils, FHIRFilterOperator, FHIRFilterComplexOperator, ChangeReason, merge, deepEqual, Filter, Sorter) {
 
 	"use strict";
 
@@ -36,7 +37,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.createSortParams = function(aSorters) {
+	FHIRUtils.createSortParams = function (aSorters) {
 		var sSorterURLPart;
 		if (aSorters && Array.isArray(aSorters) && aSorters.length > 0) {
 			sSorterURLPart = "";
@@ -64,12 +65,12 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.addRequestQueryParameters = function(oBinding, mParametersRequest){
-		if (oBinding.mParameters && oBinding.mParameters.hasOwnProperty("request")){
-			if (!mParametersRequest.urlParameters){
+	FHIRUtils.addRequestQueryParameters = function (oBinding, mParametersRequest) {
+		if (oBinding.mParameters && oBinding.mParameters.hasOwnProperty("request")) {
+			if (!mParametersRequest.urlParameters) {
 				mParametersRequest.urlParameters = {};
 			}
-			for (var sKey in oBinding.mParameters.request){
+			for (var sKey in oBinding.mParameters.request) {
 				mParametersRequest.urlParameters[sKey] = oBinding.mParameters.request[sKey];
 			}
 		}
@@ -84,7 +85,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.insertArrayIntoArray = function(aArray, aSubArray, iPos) {
+	FHIRUtils.insertArrayIntoArray = function (aArray, aSubArray, iPos) {
 		Array.prototype.splice.apply(aArray, [iPos, 0].concat(aSubArray));
 	};
 
@@ -97,8 +98,8 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.removeArrayFromArray = function(aArray, aSubArray) {
-		return aArray.filter(function(x) {
+	FHIRUtils.removeArrayFromArray = function (aArray, aSubArray) {
+		return aArray.filter(function (x) {
 			return aSubArray.indexOf(x) < 0;
 		});
 	};
@@ -106,17 +107,17 @@ sap.ui.define([
 	/**
 	 * Determines if the index of the first occurrence of <code>vValue</code> in the given <code>aValue</code>
 	 *
-     * @param {any} vValue The value to be checked
+	 * @param {any} vValue The value to be checked
 	 * @param {any[]} aValue The array might contains the <code>vValue</code>
 	 * @returns {number} The index of the first occurrence of <code>vValue</code> in the <code>aValue</code>
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.getIndexOfValueInArray = function(vValue, aValue){
-		if (aValue && Array.isArray(aValue)){
-			for (var i = 0; i < aValue.length; i++){
+	FHIRUtils.getIndexOfValueInArray = function (vValue, aValue) {
+		if (aValue && Array.isArray(aValue)) {
+			for (var i = 0; i < aValue.length; i++) {
 				var oEntry = aValue[i];
-				if (deepEqual(oEntry, vValue)){
+				if (deepEqual(oEntry, vValue)) {
 					return i;
 				}
 			}
@@ -135,8 +136,8 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isSubset = function(aSubCollection, aCollection) {
-		return aSubCollection.every(function(vValue) {
+	FHIRUtils.isSubset = function (aSubCollection, aCollection) {
+		return aSubCollection.every(function (vValue) {
 			return aCollection.indexOf(vValue) >= 0;
 		});
 	};
@@ -149,7 +150,7 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isQuantity = function(vValue) {
+	FHIRUtils.isQuantity = function (vValue) {
 		return false;
 	};
 
@@ -161,7 +162,7 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isString = function(vValue) {
+	FHIRUtils.isString = function (vValue) {
 		return typeof vValue === "string";
 	};
 
@@ -173,7 +174,7 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isObject = function(vValue) {
+	FHIRUtils.isObject = function (vValue) {
 		return typeof vValue === "object";
 	};
 
@@ -185,7 +186,7 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isNumber = function(vValue) {
+	FHIRUtils.isNumber = function (vValue) {
 		return typeof vValue === "number";
 	};
 
@@ -198,7 +199,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isEmptyObject = function(oObject) {
+	FHIRUtils.isEmptyObject = function (oObject) {
 		for (var sName in oObject) {
 			return false;
 		}
@@ -222,8 +223,8 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.filterArray = function(aArray, sAttribute, sFilterValue, fnCallback) {
-		return aArray.filter(function(oArrayAttribute) {
+	FHIRUtils.filterArray = function (aArray, sAttribute, sFilterValue, fnCallback) {
+		return aArray.filter(function (oArrayAttribute) {
 			if (fnCallback) {
 				return fnCallback(oArrayAttribute);
 			} else {
@@ -245,9 +246,9 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.filterObject = function(oObject, sAttribute, sFilterValue, iLevel, aObjects, fnPreprocessResult) {
+	FHIRUtils.filterObject = function (oObject, sAttribute, sFilterValue, iLevel, aObjects, fnPreprocessResult) {
 		if (iLevel > 0) {
-			for ( var sKey in oObject) {
+			for (var sKey in oObject) {
 				this.filterObject(oObject[sKey], sAttribute, sFilterValue, iLevel - 1, aObjects, fnPreprocessResult);
 			}
 		}
@@ -269,7 +270,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.deepClone = function(oObject) {
+	FHIRUtils.deepClone = function (oObject) {
 		if (oObject && typeof oObject === "object") {
 			if (Array.isArray(oObject)) {
 				return merge([], oObject);
@@ -291,8 +292,8 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.uuidv4 = function() {
-		return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
+	FHIRUtils.uuidv4 = function () {
+		return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
 			var r = Math.floor(Math.random() * 16), v = c === "x" ? r : r % 4 + 8;
 			return v.toString(16);
 		});
@@ -307,7 +308,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.getLinkUrl = function(aLinks, sRelation) {
+	FHIRUtils.getLinkUrl = function (aLinks, sRelation) {
 		var oLink = this.filterArray(aLinks, "relation", sRelation)[0];
 		return oLink && oLink.url ? oLink.url : undefined;
 	};
@@ -320,7 +321,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.getNumberOfLevelsByPath = function(sPath) {
+	FHIRUtils.getNumberOfLevelsByPath = function (sPath) {
 		return this.countOccurrence(sPath, "/");
 	};
 
@@ -333,14 +334,14 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.countOccurrence = function(sBase, sSearch) {
+	FHIRUtils.countOccurrence = function (sBase, sSearch) {
 		var iCount = -1;
 
-		if (sBase === undefined){
+		if (sBase === undefined) {
 			throw new Error("sBase is undefined");
 		}
 
-		if (!this.isString(sBase)){
+		if (!this.isString(sBase)) {
 			throw new Error("sBase is not a string");
 		}
 
@@ -360,7 +361,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.checkStringParameter = function(mParameters, sParameter) {
+	FHIRUtils.checkStringParameter = function (mParameters, sParameter) {
 		if (!mParameters.hasOwnProperty(sParameter)) {
 			throw new Error("Missing parameter: '" + sParameter + "'.");
 		} else if (!FHIRUtils.isString(mParameters[sParameter])) {
@@ -377,7 +378,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.checkPathParameter = function(mParameters, sParameter) {
+	FHIRUtils.checkPathParameter = function (mParameters, sParameter) {
 		this.checkStringParameter(mParameters, sParameter);
 		if (mParameters[sParameter].startsWith("/")) {
 			throw new Error("Unsupported parameter: '" + sParameter + "'. Parameter must not start with a '/'.");
@@ -395,7 +396,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.checkFHIRSearchParameter = function(mParameters, sParameter) {
+	FHIRUtils.checkFHIRSearchParameter = function (mParameters, sParameter) {
 		this.checkStringParameter(mParameters, sParameter);
 	};
 
@@ -408,7 +409,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.checkRegularExpression = function(sText, rRegExp) {
+	FHIRUtils.checkRegularExpression = function (sText, rRegExp) {
 		if (!sText) {
 			throw new Error("Empty string. Can not check the regular expression: " + rRegExp + " for an undefined text.");
 		}
@@ -426,7 +427,7 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.splitPath = function(sPath) {
+	FHIRUtils.splitPath = function (sPath) {
 		var rSliceableExpression = /((\s*(\[|§)(.*?)(\]|§)\s*)+)/g;
 		var aMatches = sPath.match(rSliceableExpression);
 		var sPathWithoutSlices = sPath.replace(rSliceableExpression, "");
@@ -452,11 +453,11 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.filterBuilder = function(aFilters, mParameters, iSupportedFilterDepth, bIsValueSet, iLvl, bLogicalConnection, bLogicalOperator){
-		if (iLvl === undefined){
+	FHIRUtils.filterBuilder = function (aFilters, mParameters, iSupportedFilterDepth, bIsValueSet, iLvl, bLogicalConnection, bLogicalOperator) {
+		if (iLvl === undefined) {
 			iLvl = 0;
 		}
-		if (aFilters){
+		if (aFilters) {
 			for (var i = 0; i < aFilters.length; i++) {
 				var oFilter = aFilters[i];
 				if (!iSupportedFilterDepth) {
@@ -464,7 +465,7 @@ sap.ui.define([
 						mParameters._filter = "";
 					}
 					this._complexFilterBuilder(oFilter, mParameters, undefined);
-				} else if (oFilter._bMultiFilter && iLvl <= iSupportedFilterDepth){
+				} else if (oFilter._bMultiFilter && iLvl <= iSupportedFilterDepth) {
 					this.filterBuilder(oFilter.aFilters, mParameters, iSupportedFilterDepth, bIsValueSet, iLvl + 1, oFilter._bMultiFilter, oFilter.bAnd);
 				} else if (iLvl > iSupportedFilterDepth) {
 					throw new Error("A depth of " + iLvl + " is not supported for simple filtering, please reduce it to a maximum of 2");
@@ -486,13 +487,13 @@ sap.ui.define([
 	 * @private
 	 * @since 1.0.0
 	 */
-	FHIRUtils._filterBuilder = function(oFilter, mParameters, bIsValueSet, bLogicalConnection, bLogicalOperator){
+	FHIRUtils._filterBuilder = function (oFilter, mParameters, bIsValueSet, bLogicalConnection, bLogicalOperator) {
 		var sPath = oFilter.sPath;
 		var sFhirSearchModifier = FHIRFilterOperatorUtils.getFHIRSearchParameterModifier(oFilter);
 		var oValue1 = FHIRFilterOperatorUtils.getFilterValue(oFilter.oValue1);
 		var sSearchPrefix = FHIRFilterOperatorUtils.getFHIRSearchPrefix(oFilter);
 		var vValue;
-		if (sSearchPrefix){
+		if (sSearchPrefix) {
 			vValue = sSearchPrefix + oValue1;
 		} else {
 			vValue = oValue1;
@@ -502,14 +503,14 @@ sap.ui.define([
 		} else if (oFilter.sOperator === FHIRFilterOperator.BT) {
 			var oValue2 = FHIRFilterOperatorUtils.getFilterValue(oFilter.oValue2);
 			mParameters[sPath + sFhirSearchModifier] = ["ge" + oValue1, "le" + oValue2];
-		} else if (bLogicalConnection && !bLogicalOperator){
-			if (mParameters[sPath + sFhirSearchModifier]){
+		} else if (bLogicalConnection && !bLogicalOperator) {
+			if (mParameters[sPath + sFhirSearchModifier]) {
 				mParameters[sPath + sFhirSearchModifier].push(vValue);
 			} else {
-				mParameters[sPath + sFhirSearchModifier] = [ vValue ];
+				mParameters[sPath + sFhirSearchModifier] = [vValue];
 			}
 		} else {
-			mParameters[sPath + sFhirSearchModifier] =  vValue;
+			mParameters[sPath + sFhirSearchModifier] = vValue;
 		}
 	};
 
@@ -545,7 +546,7 @@ sap.ui.define([
 				var oValue1 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue1);
 				var oValue2;
 				var sFilter;
-				if (oFilter.sOperator === FHIRFilterOperator.BT) {
+				if (oFilter.sOperator === FHIRFilterComplexOperator.BT) {
 					oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
 					sFilter = "( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " )";
 				} else {
@@ -568,23 +569,23 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.filter = function(aFilters, oBinding){
+	FHIRUtils.filter = function (aFilters, oBinding) {
 		if (!aFilters) {
 			aFilters = [];
 		}
 		if (aFilters instanceof Filter) {
 			aFilters = [aFilters];
 		}
-		if (oBinding.bPendingRequest){
-			var fnQueryLastFilters = function() {
-				if (!oBinding.bPendingRequest){
+		if (oBinding.bPendingRequest) {
+			var fnQueryLastFilters = function () {
+				if (!oBinding.bPendingRequest) {
 					oBinding.detachDataReceived(fnQueryLastFilters);
 					oBinding.bIsDataReceivedAttached = false;
 					oBinding.aFilters = oBinding.aFilterCache;
 					oBinding.refresh(ChangeReason.Filter);
 				}
 			};
-			if (!oBinding.bIsDataReceivedAttached){
+			if (!oBinding.bIsDataReceivedAttached) {
 				oBinding.bIsDataReceivedAttached = true;
 				oBinding.attachDataReceived(fnQueryLastFilters);
 			}
@@ -604,32 +605,32 @@ sap.ui.define([
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.sort = function(aSorters, oBinding, bRefresh){
+	FHIRUtils.sort = function (aSorters, oBinding, bRefresh) {
 		if (!aSorters) {
 			aSorters = [];
 		}
 		if (aSorters instanceof Sorter) {
 			aSorters = [aSorters];
 		}
-		if (oBinding.bPendingRequest){
-			var fnQueryLastSorters = function() {
-				if (!oBinding.bPendingRequest){
+		if (oBinding.bPendingRequest) {
+			var fnQueryLastSorters = function () {
+				if (!oBinding.bPendingRequest) {
 					oBinding.detachDataReceived(fnQueryLastSorters);
 					oBinding.bIsDataReceivedAttached = false;
 					oBinding.aSorters = oBinding.aSortersCache;
-					if (bRefresh){
+					if (bRefresh) {
 						oBinding.refresh(ChangeReason.Sort);
 					}
 				}
 			};
-			if (!oBinding.bIsDataReceivedAttached){
+			if (!oBinding.bIsDataReceivedAttached) {
 				oBinding.bIsDataReceivedAttached = true;
 				oBinding.attachDataReceived(fnQueryLastSorters);
 			}
 			oBinding.aSortersCache = aSorters;
 		} else {
 			oBinding.aSorters = aSorters;
-			if (bRefresh){
+			if (bRefresh) {
 				oBinding.refresh(ChangeReason.Sort);
 			}
 		}
@@ -643,7 +644,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isRequestable = function(sPath) {
+	FHIRUtils.isRequestable = function (sPath) {
 		return sPath && (sPath.indexOf("$") > -1 || (sPath.match(/\//g) || []).length <= 2 || sPath.indexOf("_history") > -1);
 	};
 
@@ -655,7 +656,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isContextBinding = function(oContext) {
+	FHIRUtils.isContextBinding = function (oContext) {
 		return oContext && oContext.getMetadata().getName() === "sap.fhir.model.r4.FHIRContextBinding";
 	};
 
@@ -667,7 +668,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.0.0
 	 */
-	FHIRUtils.isPropertyBinding = function(oBinding) {
+	FHIRUtils.isPropertyBinding = function (oBinding) {
 		return oBinding && oBinding.getMetadata().getName() === "sap.fhir.model.r4.FHIRPropertyBinding";
 	};
 
@@ -682,7 +683,7 @@ sap.ui.define([
 	 * @protected
 	 * @since 1.1.0
 	 */
-	FHIRUtils.generateFullUrl = function(oUri, sResourceServerPath, sResourceId, sServiceUrl) {
+	FHIRUtils.generateFullUrl = function (oUri, sResourceServerPath, sResourceId, sServiceUrl) {
 		var sFullUrl;
 		if (oUri) {
 			switch (oUri.getName()) {

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -518,7 +518,7 @@ sap.ui.define([
 	 *
 	 * @param {object} oFilter The filter which should be added to the parameters
 	 * @param {object} mParameters The parameters which should be passed to the request
-	 * @param {string} sLogicalConnection if list of filters needs to be combined either with AND or OR
+	 * @param {string} sLogicalConnection if the list of filters needs to be combined either with AND or OR
 	 * @private
 	 * @since 2.1.0
 	 */
@@ -531,20 +531,19 @@ sap.ui.define([
 					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
 				}
 				if (oFilter.aFilters) {
-					mParameters._filter = mParameters._filter + " ( ";
-					// TODO See if this can be done in a better way
+					mParameters._filter = mParameters._filter + "( ";
 					// for the first filter the logical connection shouldnt be appended
 					this._complexFilterBuilder(oFilter.aFilters[0], mParameters, undefined);
 					for (var i = 1; i < oFilter.aFilters.length; i++) {
 						this._complexFilterBuilder(oFilter.aFilters[i], mParameters, sLogicalConnection1);
 					}
-					mParameters._filter = mParameters._filter + " ) ";
+					mParameters._filter = mParameters._filter + " )";
 				}
 			} else {
 				// validate the filter operator
 				// if BT operator use 'and' to generate the filter value
 				var sPath = oFilter.sPath;
-				var sFilterOperator = oFilter.sOperator;
+				var sFilterOperator = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 				var oValue1 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue1);
 				var oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
 				var sFilter;

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -523,10 +523,10 @@ sap.ui.define([
 	 * @since 2.1.0
 	 */
 	FHIRUtils._complexFilterBuilder = function (oFilter, mParameters, sLogicalConnection) {
+		var sLogicalConnection1;
 		if (oFilter instanceof Filter) {
 			if (oFilter._bMultiFilter) {
 				// recursive
-				var sLogicalConnection1;
 				if (oFilter.bAnd != undefined) {
 					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
 				}
@@ -545,9 +545,17 @@ sap.ui.define([
 				// if BT operator use 'and' to generate the filter value
 				var sPath = oFilter.sPath;
 				var sFilterOperator = oFilter.sOperator;
-				var oValue1 = FHIRFilterOperatorUtils.getFilterValue(oFilter.oValue1);
-
-				var sFilter = sPath + " " + sFilterOperator + " " + oValue1;
+				var oValue1 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue1);
+				var oValue2 = FHIRFilterOperatorUtils.getFilterValueForComplexFilter(oFilter.sValueType, oFilter.oValue2);
+				var sFilter;
+				if (oFilter.sOperator === FHIRFilterOperator.BT) {
+					sFilter = " ( " + sPath + " ge " + oValue1 + " and " + sPath + " le " + oValue2 + " ) ";
+				} else if (oFilter.bAnd != undefined) {
+					sLogicalConnection1 = oFilter.bAnd ? " and " : " or ";
+					sFilter = " ( " + sPath + " ge " + oValue1 + sLogicalConnection1 + sPath + " le " + oValue2 + " ) ";
+				} else {
+					sFilter = sPath + " " + sFilterOperator + " " + oValue1;
+				}
 				if (sLogicalConnection) {
 					mParameters._filter = mParameters._filter + sLogicalConnection + sFilter;
 				} else {

--- a/test/qunit/model/FHIRFilterOperatorUtils.unit.js
+++ b/test/qunit/model/FHIRFilterOperatorUtils.unit.js
@@ -1,68 +1,68 @@
 sap.ui.define([
-	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterComplexOperator",
 	"sap/fhir/model/r4/FHIRFilterOperatorUtils",
 	"sap/fhir/model/r4/FHIRFilter"
-], function (FHIRFilterOperator, FHIRFilterOperatorUtils, FHIRFilter) {
+], function (FHIRFilterComplexOperator, FHIRFilterOperatorUtils, FHIRFilter) {
 	"use strict";
 
 	QUnit.module("Unit-Tests: FHIRFilterOperatorUtils", {});
 
 	QUnit.test("Test function getFHIRFilterPrefix ", function (assert) {
-		var oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EQ });
+		var oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EQ });
 		var sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("eq", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.NE });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.NE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ne", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.GE });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.GE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ge", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.LE });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.LE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("le", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.StartsWith });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.StartsWith });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sw", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EndsWith });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EndsWith });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ew", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.GT });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.GT });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("gt", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.LT });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.LT });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("lt", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SA });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SA });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sa", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EB });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EB });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("eb", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.AP });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.AP });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ap", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.PR });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.PR });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("pr", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.PO });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.PO });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("po", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.IN });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.IN });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("in", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SS });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SS });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ss", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SB });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SB });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sb", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.RE });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.RE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("re", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.Contains });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.Contains });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("co", sFHIRFilterPrefix);
-		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.NI });
+		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.NI });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ni", sFHIRFilterPrefix);
 	});

--- a/test/qunit/model/FHIRFilterOperatorUtils.unit.js
+++ b/test/qunit/model/FHIRFilterOperatorUtils.unit.js
@@ -11,57 +11,75 @@ sap.ui.define([
 		var oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EQ });
 		var sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("eq", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.NE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ne", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.GE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ge", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.LE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("le", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.StartsWith });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sw", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EndsWith });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ew", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.GT });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("gt", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.LT });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("lt", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SA });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sa", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.EB });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("eb", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.AP });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ap", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.PR });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("pr", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.PO });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("po", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.IN });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("in", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SS });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ss", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.SB });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("sb", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.RE });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("re", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.Contains });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("co", sFHIRFilterPrefix);
+
 		oFilter = new FHIRFilter({ operator: FHIRFilterComplexOperator.NI });
 		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
 		assert.strictEqual("ni", sFHIRFilterPrefix);

--- a/test/qunit/model/FHIRFilterOperatorUtils.unit.js
+++ b/test/qunit/model/FHIRFilterOperatorUtils.unit.js
@@ -1,0 +1,69 @@
+sap.ui.define([
+	"sap/fhir/model/r4/FHIRFilterOperator",
+	"sap/fhir/model/r4/FHIRFilterOperatorUtils",
+	"sap/fhir/model/r4/FHIRFilter"
+], function (FHIRFilterOperator, FHIRFilterOperatorUtils, FHIRFilter) {
+	"use strict";
+
+	QUnit.module("Unit-Tests: FHIRFilterOperatorUtils", {});
+
+	QUnit.test("Test function getFHIRFilterPrefix ", function (assert) {
+		var oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EQ });
+		var sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("eq", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.NE });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ne", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.GE });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ge", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.LE });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("le", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.StartsWith });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("sw", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EndsWith });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ew", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.GT });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("gt", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.LT });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("lt", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SA });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("sa", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.EB });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("eb", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.AP });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ap", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.PR });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("pr", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.PO });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("po", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.IN });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("in", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SS });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ss", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.SB });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("sb", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.RE });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("re", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.Contains });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("co", sFHIRFilterPrefix);
+		oFilter = new FHIRFilter({ operator: FHIRFilterOperator.NI });
+		sFHIRFilterPrefix = FHIRFilterOperatorUtils.getFHIRFilterPrefix(oFilter);
+		assert.strictEqual("ni", sFHIRFilterPrefix);
+	});
+});

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -125,9 +125,9 @@ sap.ui.define([
 		assert.throws(function() {return TestUtils.createFHIRModel();}, new Error("Missing service root URL"), "Error with message 'Missing service root URL' is thrown");
 	});
 
-	QUnit.test("initialize model with complex filtering", function(assert) {
+	QUnit.test("initialize model with complex filtering", function (assert) {
 		var oFhirModel = createModel({ simpleFiltering: false });
-		assert.strictEqual(oFhirModel.iSupportedFilterDepth,undefined);
+		assert.strictEqual(oFhirModel.iSupportedFilterDepth, undefined);
 	});
 
 	QUnit.test("filter test with multiple group filters", function(assert) {
@@ -1265,6 +1265,7 @@ sap.ui.define([
 	});
 
 	QUnit.test("complex filter test with multiple group filters", function (assert) {
+		// simple filter query
 		var oFhirModel = createModel({ simpleFiltering: false });
 		var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger", valueType: FHIRFilterType.string });
 		var aFilters = [oNameFilter];
@@ -1274,6 +1275,8 @@ sap.ui.define([
 		var oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
 		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Ruediger\"", "The _filter parameter object is the same");
 		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Ruediger%22") > -1, true, "The url is encoded for _filter parameter");
+
+		// multivalued filter
 		var oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger", valueType: FHIRFilterType.string });
 		var oNameFilter2 = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Habibi", valueType: FHIRFilterType.string });
 		var oCombinedFilter = new sap.ui.model.Filter([oNameFilter1, oNameFilter2], false);
@@ -1282,18 +1285,24 @@ sap.ui.define([
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( name eq \"Ruediger\" or name eq \"Habibi\" )", "The _filter parameter for array of filters is the formed correctly");
+
+		// multivalued filter with different value type
 		var oGenderFilter = new FHIRFilter({ path: "gender", operator: FilterOperator.EQ, value1: "male" });
 		var oCombinedFilter1 = new sap.ui.model.Filter([oCombinedFilter, oGenderFilter], true);
 		aFilters = [oCombinedFilter1];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq male )", "The _filter parameter object is the same");
+
+		//filter with BT operator
 		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });
 		aFilters = [oBirthDateFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( birthdate ge 1965-03-23 and birthdate le 1985-04-14 )", "The _filter parameter for BT operator is the formed correctly");
+
+		// filter with StartsWith and EndsWith Operator
 		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.StartsWith, value1: "Ra", valueType: FHIRFilterType.string });
 		oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "er", valueType: FHIRFilterType.string });
 		oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1281,13 +1281,19 @@ sap.ui.define([
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
-		assert.deepEqual(mParameters.urlParameters["_filter"], "( name eq \"Ruediger\" or name eq \"Habibi\" )", "The _filter parameter object is the same");
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( name eq \"Ruediger\" or name eq \"Habibi\" )", "The _filter parameter for array of filters is the formed correctly");
 		var oGenderFilter = new FHIRFilter({ path: "gender", operator: FilterOperator.EQ, value1: "male" });
 		var oCombinedFilter1 = new sap.ui.model.Filter([oCombinedFilter, oGenderFilter], true);
 		aFilters = [oCombinedFilter1];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq male )", "The _filter parameter object is the same");
+		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });
+		aFilters = [oBirthDateFilter];
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], " ( birthdate ge 1965-03-23 and birthdate le 1985-04-14 ) ", "The _filter parameter for BT operator is the formed correctly");
 	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -126,7 +126,7 @@ sap.ui.define([
 	});
 
 	QUnit.test("initialize model with complex filtering", function (assert) {
-		var oFhirModel = createModel({ simpleFiltering: false });
+		var oFhirModel = createModel({ filtering: { complex: true } });
 		assert.strictEqual(oFhirModel.iSupportedFilterDepth, undefined);
 	});
 
@@ -1266,7 +1266,7 @@ sap.ui.define([
 
 	QUnit.test("complex filter test with multiple group filters", function (assert) {
 		// simple filter query
-		var oFhirModel = createModel({ simpleFiltering: false });
+		var oFhirModel = createModel({ filtering: { complex: true } });
 		var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger", valueType: FHIRFilterType.string });
 		var aFilters = [oNameFilter];
 		var oListBinding = oFhirModel.bindList("/Patient");
@@ -1294,7 +1294,7 @@ sap.ui.define([
 		mParameters = oListBinding._buildParameters();
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq male )", "The _filter parameter object is the same");
 
-		//filter with BT operator
+		// filter with BT operator
 		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });
 		aFilters = [oBirthDateFilter];
 		oListBinding.filter(aFilters);

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1293,7 +1293,15 @@ sap.ui.define([
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
-		assert.deepEqual(mParameters.urlParameters["_filter"], " ( birthdate ge 1965-03-23 and birthdate le 1985-04-14 ) ", "The _filter parameter for BT operator is the formed correctly");
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( birthdate ge 1965-03-23 and birthdate le 1985-04-14 )", "The _filter parameter for BT operator is the formed correctly");
+		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.StartsWith, value1: "Ra", valueType: FHIRFilterType.string });
+		oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EndsWith, value1: "er", valueType: FHIRFilterType.string });
+		oCombinedFilter = new sap.ui.model.Filter([oNameFilter, oNameFilter1], true);
+		aFilters = [oCombinedFilter];
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( name sw \"Ra\" and name ew \"er\" )", "The _filter parameter for StartsWith and EndsWith operator is the formed correctly");
 	});
 
 });

--- a/test/qunit/unit.js
+++ b/test/qunit/unit.js
@@ -1,6 +1,7 @@
 sap.ui.define([
 	"./model/FHIRUtils.unit",
 	"./model/FHIRUrl.unit",
+	"./model/FHIRFilterOperatorUtils.unit",
 	"./model/FHIRModel.unit",
 	"./model/FHIRModel.integration",
 	"./model/FHIRTreeBinding.unit",


### PR DESCRIPTION
This PR contains the implementation for the support of _filter (https://www.hl7.org/fhir/search_filter.html)
_filter is an advanced search mechanism
Using the simpleFiltering value during the initialisation of model determines whether the request would be using _filter or regular search 
If the FilterType is of string then the filter value would be encoded with "" 
Using the bAnd key of Ui5 filter the logical connection value is determined to be `and` or `or`
Some of the examples on how the _filter value is generated
**To get the patients whose names are either Habibi or Damon**
`name eq "Habibi" or name eq "Damon"`
**To get the male patients whose names are either Habibi or Damon**
`gender eq male and (name eq "Habibi" or name eq "Damon")`

