### PR TITLE
feat: Implement RESTful Search Via POST

### DIFF
--- a/docs/tutorials/4 Request Handling.md
+++ b/docs/tutorials/4 Request Handling.md
@@ -45,8 +45,9 @@ onSavePress: function(){
 ```
 
 #### Step 4.1.1: RESTful based `Search` via POST Requests
-When a FHIR® server supports GET in Search requests it could mean that PHI (Personal health information) might appear in search parameters and https logs. To prevent such sensitive information from being logged FHIR® specification suggests the server that support `search` SHALL also support a [POST](https://www.hl7.org/fhir/http.html#search) based search.
-To enable this feature from the model the `manifest.json ` is initialised with the following settings
+When a FHIR® server supports `GET` in search requests it could mean that `PHI (Personal health information)` might appear in search parameters and thereby https logs. To prevent such sensitive information from being logged FHIR® specification suggests the server that support `search` SHALL also support a [POST](https://www.hl7.org/fhir/http.html#search) based search.
+
+To enable this feature from the model the `manifest.json` is initialised with the following settings
 ```json
 "models": {
     "": {

--- a/docs/tutorials/4 Request Handling.md
+++ b/docs/tutorials/4 Request Handling.md
@@ -44,6 +44,23 @@ onSavePress: function(){
 }
 ```
 
+#### Step 4.1.1: RESTful based `Search` via POST Requests
+When a FHIR® server supports GET in Search requests it could mean that PHI (Personal health information) might appear in search parameters and https logs. To prevent such sensitive information from being logged FHIR® specification suggests the server that support `search` SHALL also support a [POST](https://www.hl7.org/fhir/http.html#search) based search.
+To enable this feature from the model the `manifest.json ` is initialised with the following settings
+```json
+"models": {
+    "": {
+        "type": "sap.fhir.model.r4.FHIRModel",
+        "dataSource": "local",
+        "settings": {
+            "search":{
+                "secure": true
+            }
+        }
+    }
+}
+```
+
 ### Step 4.2: Bundle Requests
 <table>
   <tr valign="top">

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -174,13 +174,28 @@ sap.ui.define([
 				this._submitRequest("/ValueSet/$expand", mParameters, fnSuccessValueSet);
 			} else if (!this.aSortersCache && !this.aFilterCache && this.sNextLink && iLength > this.iLastLength) {
 				this.iLastLength += this.iLength;
-				this._submitRequest(this.sNextLink, undefined, fnSuccess, true);
+				// if secure search is enabled convert the next link so that the subsequent calls are handled appropriately
+				if (this.oModel.isSecureSearchModeEnabled() && this.sNextLink && this.sNextLink.indexOf("?") > -1) {
+					var sQueryParams = this.sNextLink.substring(this.sNextLink.indexOf("?") + 1, this.sNextLink.length);
+					var aParameter = sQueryParams ? sQueryParams.split("&") : [];
+					var aKeyValue;
+					for (var i = 0; i < aParameter.length; i++) {
+						aKeyValue = aParameter[i].split("=");
+						mParameters.urlParameters[aKeyValue[0]] = aKeyValue[1];
+					}
+					this._submitRequest(this.sPath, mParameters, fnSuccess, true);
+				} else {
+					this._submitRequest(this.sNextLink, undefined, fnSuccess, true);
+				}
 			} else if (this.iTotalLength === undefined){ // load context based resources
 				this.iLastLength = this.iLength;
 				this._loadProfile(fnSuccessStructDef, fnLoadResources, fnSuccess, mParameters, iLength);
 			} else if (!this._isValueSet()){
 				if (iLength > this.iLastLength){
 					this.iLastLength += this.iLength;
+				}
+				if (!this.iLastLength){
+					this.iLastLength = this.iLength;
 				}
 				this._loadResources(this.iLastLength);
 			}

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -64,6 +64,7 @@ sap.ui.define([
 	 * @param {boolean} [mParameters.x-csrf-token=false] The model handles the csrf token between the browser and the FHIR server
 	 * @param {object} [mParameters.filtering={}] The filtering options
 	 * @param {boolean} [mParameters.filtering.complex=false] The default filtering type. If <code>true</code>, all search parameters would be modelled via {@link https://www.hl7.org/fhir/search_filter.html _filter}
+	 * @param {boolean} [mParameters.securesearch=false] To enable RESTful search via {@link https://www.hl7.org/fhir/http.html#search POST}
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
 	 * @author SAP SE
 	 * @public
@@ -86,6 +87,7 @@ sap.ui.define([
 			this.sBaseProfileUrl = mParameters && mParameters.baseProfileUrl ? mParameters.baseProfileUrl : "http://hl7.org/fhir/StructureDefinition/";
 			this._buildGroupProperties(mParameters);
 			this.oDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Object ? mParameters.defaultQueryParameters : {};
+			this.bSecureSearch = mParameters && mParameters.securesearch ? mParameters.securesearch : false;
 			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.oDefaultQueryParameters);
 			this.sDefaultSubmitMode = (mParameters && mParameters.defaultSubmitMode) ? mParameters.defaultSubmitMode : SubmitMode.Direct;
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";
@@ -597,7 +599,6 @@ sap.ui.define([
 				}
 				var oBinding = mParameters.binding;
 				var sGroupId = mParameters.groupId || (oBinding && oBinding.sGroupId);
-
 				var fnSuccess = function(oRequestHandle, oResponse, oBundleEntry) {
 					if (!oResponse){
 						oResponse = oRequestHandle.getRequest().responseJSON;
@@ -1623,6 +1624,17 @@ sap.ui.define([
 			return false;
 		}
 		return true;
+	};
+
+	/**
+	 * Determines the value of securesearch mode
+	 *
+	 * @returns {boolean} The value of secure search mode
+	 * @protected
+	 * @since 2.2.0
+	 */
+	FHIRModel.prototype.isSecureSearchModeEnabled = function () {
+		return this.bSecureSearch;
 	};
 
 	return FHIRModel;

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -64,7 +64,8 @@ sap.ui.define([
 	 * @param {boolean} [mParameters.x-csrf-token=false] The model handles the csrf token between the browser and the FHIR server
 	 * @param {object} [mParameters.filtering={}] The filtering options
 	 * @param {boolean} [mParameters.filtering.complex=false] The default filtering type. If <code>true</code>, all search parameters would be modelled via {@link https://www.hl7.org/fhir/search_filter.html _filter}
-	 * @param {boolean} [mParameters.securesearch=false] To enable RESTful search via {@link https://www.hl7.org/fhir/http.html#search POST}
+	 * @param {boolean} [mParameters.search={}] The search options
+	 * @param {boolean} [mParameters.search.secure=false] To enable RESTful search via {@link https://www.hl7.org/fhir/http.html#search POST}
 	 * @throws {Error} If no service URL is given, if the given service URL does not end with a forward slash
 	 * @author SAP SE
 	 * @public
@@ -87,7 +88,7 @@ sap.ui.define([
 			this.sBaseProfileUrl = mParameters && mParameters.baseProfileUrl ? mParameters.baseProfileUrl : "http://hl7.org/fhir/StructureDefinition/";
 			this._buildGroupProperties(mParameters);
 			this.oDefaultQueryParameters = mParameters && mParameters.defaultQueryParameters && mParameters.defaultQueryParameters instanceof Object ? mParameters.defaultQueryParameters : {};
-			this.bSecureSearch = mParameters && mParameters.securesearch ? mParameters.securesearch : false;
+			this.bSecureSearch = mParameters && mParameters.search && mParameters.search.secure ? mParameters.search.secure : false;
 			this.oRequestor = new FHIRRequestor(sServiceUrl, this, mParameters && mParameters["x-csrf-token"], mParameters && mParameters.Prefer, this.oDefaultQueryParameters);
 			this.sDefaultSubmitMode = (mParameters && mParameters.defaultSubmitMode) ? mParameters.defaultSubmitMode : SubmitMode.Direct;
 			this.sDefaultFullUrlType = (mParameters && mParameters.defaultSubmitMode && mParameters.defaultSubmitMode !== SubmitMode.Direct && mParameters.defaultFullUrlType) ? mParameters.defaultFullUrlType : "uuid";

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -231,10 +231,7 @@ sap.ui.define([
 		var sRequestUrl;
 		var sContentType = "application/json";
 		var oBindingInfo = this.oModel.getBindingInfo(oFHIRUrl.getRelativeUrlWithoutQueryParameters());
-		// if the method is GET, secure search is enabled
-		// convert the path to _search and all the url paramters will be converted to POST form data
-		// except ValueSet/$expand or specific operations  like Patient/53/_history
-		if (this._canRequestBeTransformed(sMethod, oFHIRUrl)) {
+		if (this._isRequestTransformable(sMethod, oFHIRUrl)) {
 			sMethod = HTTPMethod.POST;
 			oPayload = this._getFormData(mParameters, oBindingInfo, oFHIRUrl.getQueryParameters());
 			sRequestUrl = this._sServiceUrl + "/" + oFHIRUrl.getResourceType() + "/_search";
@@ -625,7 +622,10 @@ sap.ui.define([
 	 * @private
 	 * @since 2.2.0
 	 */
-	FHIRRequestor.prototype._canRequestBeTransformed = function (sMethod, oFHIRUrl) {
+	FHIRRequestor.prototype._isRequestTransformable = function (sMethod, oFHIRUrl) {
+		// if the method is GET, secure search is enabled
+		// convert the path to _search and all the url paramters will be converted to POST form data
+		// except ValueSet/$expand or specific operations  like Patient/53/_history
 		return sMethod == HTTPMethod.GET && this.oModel.isSecureSearchModeEnabled() && oFHIRUrl.isSearchAtBaseLevel() && !this._isCsrfTokenRequest();
 	};
 

--- a/src/sap/fhir/model/r4/lib/FHIRUrl.js
+++ b/src/sap/fhir/model/r4/lib/FHIRUrl.js
@@ -33,9 +33,10 @@ sap.ui.define([], function() {
 		}
 		var aRelativeUrlWithoutQueryParameter = this._sRelativeUrlWithoutQueryParameters ? this._sRelativeUrlWithoutQueryParameters.split("/") : undefined;
 		this._sResourceType = aRelativeUrlWithoutQueryParameter ? aRelativeUrlWithoutQueryParameter[1] : undefined;
-		this._sResourceId = aRelativeUrlWithoutQueryParameter && aRelativeUrlWithoutQueryParameter.length >= 3 ? aRelativeUrlWithoutQueryParameter[2] : undefined;
-		this._sHistoryVersion = aRelativeUrlWithoutQueryParameter && aRelativeUrlWithoutQueryParameter.length === 5 ? aRelativeUrlWithoutQueryParameter[4] : undefined;
+		this._sResourceId = aRelativeUrlWithoutQueryParameter && aRelativeUrlWithoutQueryParameter.length >= 3 && !aRelativeUrlWithoutQueryParameter[2].includes("$") ? aRelativeUrlWithoutQueryParameter[2] : undefined;
+		this._sHistoryVersion = aRelativeUrlWithoutQueryParameter && aRelativeUrlWithoutQueryParameter.indexOf("_history") > -1 ? aRelativeUrlWithoutQueryParameter[aRelativeUrlWithoutQueryParameter.indexOf("_history") + 1] : undefined;
 		this._mQueryParameter = FHIRUrl.getQueryParametersByUrl(this._sRelativeUrlWithQueryParameters);
+		this._sCustomOperation = this._sRelativeUrlWithoutQueryParameters && this._sRelativeUrlWithoutQueryParameters.indexOf("$") > -1 ? this._sRelativeUrlWithoutQueryParameters.substring(this._sRelativeUrlWithoutQueryParameters.indexOf("$"), this._sRelativeUrlWithoutQueryParameters.length) : undefined;
 	};
 
 	/**
@@ -148,6 +149,28 @@ sap.ui.define([], function() {
 			}
 		}
 		return undefined;
+	};
+
+	/**
+	 * Determines the FHIR custom operation value of the configured url, e.g. /Patient/$test
+	 *
+	 * @returns {string} The custom operation value e.g $test
+	 * @protected
+	 * @since 2.2.0
+	 */
+	FHIRUrl.prototype.getCustomOperation = function () {
+		return this._sCustomOperation;
+	};
+
+	/**
+	 * Determines if its search at base level, e.g /Patient
+	 *
+	 * @returns {boolean} True if its search
+	 * @protected
+	 * @since 2.2.0
+	 */
+	FHIRUrl.prototype.isSearchAtBaseLevel = function () {
+		return !this._sResourceId && !this._sHistoryVersion && !this._sCustomOperation;
 	};
 
 	return FHIRUrl;

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1324,7 +1324,7 @@ sap.ui.define([
 	});
 
 	QUnit.test("RESTful search tests", function (assert) {
-		var oFhirModel = createModel({ "securesearch": true });
+		var oFhirModel = createModel({ "search": { "secure": true } });
 		// simple search call without query parameters
 		var oRequestHandle = oFhirModel.loadData("/Patient");
 		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/_search", "Search GET calls are converted to POST _search call");

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1323,4 +1323,80 @@ sap.ui.define([
 		assert.deepEqual(mParameters.urlParameters["_filter"], sFilterParams, "The _filter parameter for instance of type date is the formed correctly");
 	});
 
+	QUnit.test("RESTful search tests", function (assert) {
+		var oFhirModel = createModel({ "securesearch": true });
+		// simple search call without query parameters
+		var oRequestHandle = oFhirModel.loadData("/Patient");
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/_search", "Search GET calls are converted to POST _search call");
+		assert.strictEqual(oRequestHandle.getData(), "_format=json", "Secure search POST body is formed correctly without query parameters");
+
+		// simple search call with query parameters
+		oRequestHandle = oFhirModel.loadData("/Patient?gender=male");
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/_search", "Search GET calls are converted to POST _search call");
+		assert.strictEqual(oRequestHandle.getData(), "gender=male&_format=json", "Secure search POST body is formed correctly with query parameters");
+
+		// read by id call with query parameters
+		oRequestHandle = oFhirModel.loadData("/Patient/123?gender=male");
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/123?gender=male", "Query parameters that are not part of search requests at resource level is not converted to POST _search call");
+
+		// history operation
+		oRequestHandle = oFhirModel.loadData("/Patient/123/_history/1");
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/123/_history/1?_format=json", "History operation is not converted to POST _search call");
+
+		// custom operation
+		oRequestHandle = oFhirModel.loadData("/Patient/123/$look-up");
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/123/$look-up?_format=json", "Any custom operation call is not converted to POST _search call");
+
+		// search call with url parameters
+		var mParameters = {
+			urlParameters: {
+				gender: "male"
+			}
+		};
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/_search", "Search GET calls having custom url parameters are converted to POST _search call");
+		assert.strictEqual(oRequestHandle.getData(), "gender=male&_format=json", "Secure search POST body with custom url parameters is formed correctly with query parameters");
+
+		// list binding
+		var oListBinding = oFhirModel.bindList("/Account");
+		oListBinding.getContexts(0, 10);
+		var bFound = false;
+		oFhirModel.oRequestor._aPendingRequestHandles.forEach(function (oEntry, i) {
+			if (oEntry.getUrl().endsWith("Account/_search")) {
+				bFound = true;
+				assert.strictEqual(oEntry.getData(), "_count=10&_format=json", "The form data of the listbinding with RESTful search is correct");
+			}
+		});
+		assert.strictEqual(bFound, true, "The request of the listbinding with RESTful search is triggered correctly");
+
+		// list binding with filters
+		oListBinding = oFhirModel.bindList("/Organization");
+		var oNameFilter = new sap.ui.model.Filter({ path: "name", operator: "eq", value1: "TestOrg" });
+		var aFilters = [oNameFilter];
+		oListBinding.filter(aFilters);
+		oListBinding.getContexts(0, 10);
+		bFound = false;
+		oFhirModel.oRequestor._aPendingRequestHandles.forEach(function (oEntry, i) {
+			if (oEntry.getUrl().endsWith("Organization/_search")) {
+				bFound = true;
+				assert.strictEqual(oEntry.getData(), "_count=10&name=TestOrg&_format=json", "The form data of the listbinding with RESTful search is correct");
+			}
+		});
+		assert.strictEqual(bFound, true, "The request of the listbinding with RESTful search and filters is correct");
+
+		// list binding with next link
+		oListBinding = oFhirModel.bindList("/Practitioner");
+		oListBinding.sNextLink = "https://example.com/fhir/Practitioner?_getpages=1263645";
+		oListBinding.iLastLength = 10;
+		oListBinding.getContexts(0, 20);
+		bFound = false;
+		oFhirModel.oRequestor._aPendingRequestHandles.forEach(function (oEntry, i) {
+			if (oEntry.getUrl().endsWith("Practitioner/_search")) {
+				bFound = true;
+				assert.strictEqual(oEntry.getData(), "_count=10&_getpages=1263645&_format=json", "The form data of the listbinding with RESTful search is correct");
+			}
+		});
+		assert.strictEqual(bFound, true, "The request of the listbinding with next link with RESTful search is triggered correctly");
+	});
+
 });

--- a/test/qunit/model/FHIRUrl.unit.js
+++ b/test/qunit/model/FHIRUrl.unit.js
@@ -132,5 +132,24 @@ sap.ui.define(["sap/fhir/model/r4/lib/FHIRUrl"], function(FHIRUrl) {
 		assert.strictEqual(oFHIRUrl.getFullUrl("http://test.com/fhir/Patient/1234"), "http://test.com/fhir/Patient/1234");
 		assert.strictEqual(oFHIRUrl.getFullUrl("http://test.com/fhir/Patient/1234?param=value1"), "http://test.com/fhir/Patient/1234");
 		assert.strictEqual(oFHIRUrl.getFullUrl("Patient/XYZ"), undefined);
+
+		// test with custom operation
+		sUrl = "Patient/1234/$look-up";
+		oFHIRUrl = new FHIRUrl(sUrl, sServiceUrl);
+		assert.strictEqual(oFHIRUrl.getRelativeUrlWithoutQueryParameters(), "/Patient/1234/$look-up");
+		assert.strictEqual(oFHIRUrl.getRelativeUrlWithQueryParameters(), "/Patient/1234/$look-up");
+		assert.strictEqual(oFHIRUrl.getResourceType(), "Patient");
+		assert.strictEqual(oFHIRUrl.getResourceId(), "1234");
+		assert.strictEqual(oFHIRUrl.getCustomOperation(), "$look-up");
+
+		// test with custom operation
+		sUrl = "Patient/$look-up";
+		oFHIRUrl = new FHIRUrl(sUrl, sServiceUrl);
+		assert.strictEqual(oFHIRUrl.getRelativeUrlWithoutQueryParameters(), "/Patient/$look-up");
+		assert.strictEqual(oFHIRUrl.getRelativeUrlWithQueryParameters(), "/Patient/$look-up");
+		assert.strictEqual(oFHIRUrl.getResourceType(), "Patient");
+		assert.strictEqual(oFHIRUrl.getResourceId(), undefined);
+		assert.strictEqual(oFHIRUrl.getCustomOperation(), "$look-up");
+
 	});
 });


### PR DESCRIPTION
This PR enables the support for RESTful search via POST
FHIR Specification : https://www.hl7.org/fhir/http.html#search
To enable secure search the model is initialised as follows
`var mParameters = {
  search:{secure:true}
}`
If secure search is enabled in model then the search requests would be converted as follows
 `/Patient?_count=json`
`/Patient/_search`
The request body will be x-www-form-urlencoded
Only interactions which match the following pattern would be transformed
 `GET` `[base]/[type]{?[parameters]{&_format=[mime-type]}}`

Some examples which doesn't get transformed
`Patient/123`
 `Patient/123/$look-up`
 `Patient/123/history/2`
 `ValueSet/$expand`

Enhancements done to FHIRUrl.js to determine whether the url is of type resource level search
In List binding in case of next link with restful search enabled it will be converted accordingly and sent rather than direct url
Fix pagination in list binding wherein subsequent calls weren't triggered
