### PR TITLE
fix: send batch/transaction requests 

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -302,12 +302,10 @@ sap.ui.define([
 				var oResource = oData.entry[i].resource;
 				if (oResource && oResource.resourceType === "Bundle") {
 					this._mapFHIRResponse(oResource, mResponseHeaders, oBundleEntry, sGroupId);
+				} else if (!oResource && oData.entry[i].response) {
+					this._updateResourceFromFHIRResponse(oData.entry[i].response, oData.entry[i].fullUrl, oBundleEntry);
 				} else {
-					if (!oResource && oData.entry[i].response) {
-						this._updateResourceFromFHIRResponse(oData.entry[i].response, oData.entry[i].fullUrl, oBundleEntry);
-					} else {
-						this._storeResourceInModel(oResource, oBinding, sGroupId);
-					}
+					this._storeResourceInModel(oResource, oBinding, sGroupId);
 				}
 			}
 		} else if (oData.resourceType !== "Bundle") {
@@ -417,12 +415,10 @@ sap.ui.define([
 			}
 			if (oResource && oResource.resourceType == "Bundle" && oResource.entry) {
 				mResources = this._mapBundleEntriesToResourceMap(oResource.entry);
+			} else if (oResource && oResource.resourceType && oResource.id) {
+				this._setProperty(mResources, [oResource.resourceType, oResource.id], oResource, true);
 			} else {
-				if (oResource && oResource.resourceType && oResource.id) {
-					this._setProperty(mResources, [oResource.resourceType, oResource.id], oResource, true);
-				} else {
-					throw new Error("No resource could be found for bundle entry: " + aBundleEntries[i]);
-				}
+				throw new Error("No resource could be found for bundle entry: " + aBundleEntries[i]);
 			}
 		}
 		return mResources;

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -300,13 +300,17 @@ sap.ui.define([
 		if (oData.entry && oData.resourceType === "Bundle") {
 			for (var i = 0; i < oData.entry.length; i++) {
 				var oResource = oData.entry[i].resource;
-				if (!oResource && oData.entry[i].response){
-					this._updateResourceFromFHIRResponse(oData.entry[i].response, oData.entry[i].fullUrl, oBundleEntry);
+				if (oResource && oResource.resourceType === "Bundle") {
+					this._mapFHIRResponse(oResource, mResponseHeaders, oBundleEntry, sGroupId);
 				} else {
-					this._storeResourceInModel(oResource, oBinding, sGroupId);
+					if (!oResource && oData.entry[i].response) {
+						this._updateResourceFromFHIRResponse(oData.entry[i].response, oData.entry[i].fullUrl, oBundleEntry);
+					} else {
+						this._storeResourceInModel(oResource, oBinding, sGroupId);
+					}
 				}
 			}
-		} else if (oData.resourceType !== "Bundle"){
+		} else if (oData.resourceType !== "Bundle") {
 			this._storeResourceInModel(oData, oBinding, sGroupId);
 		}
 	};
@@ -403,18 +407,22 @@ sap.ui.define([
 		var mResources = {};
 		for (var i = 0; i < aBundleEntries.length; i++) {
 			var oResource;
-			if (!aBundleEntries[i]){
+			if (!aBundleEntries[i]) {
 				throw new Error("No response from the FHIR Service available");
 			}
-			if (!aBundleEntries[i].resource && aBundleEntries[i].response){
+			if (!aBundleEntries[i].resource && aBundleEntries[i].response) {
 				oResource = this._getUpdatedResourceFromFHIRResponse(aBundleEntries[i].response);
 			} else {
 				oResource = aBundleEntries[i].resource;
 			}
-			if (oResource && oResource.resourceType && oResource.id) {
-				this._setProperty(mResources, [oResource.resourceType, oResource.id], oResource, true);
+			if (oResource && oResource.resourceType == "Bundle" && oResource.entry) {
+				mResources = this._mapBundleEntriesToResourceMap(oResource.entry);
 			} else {
-				throw new Error("No resource could be found for bundle entry: " + aBundleEntries[i]);
+				if (oResource && oResource.resourceType && oResource.id) {
+					this._setProperty(mResources, [oResource.resourceType, oResource.id], oResource, true);
+				} else {
+					throw new Error("No resource could be found for bundle entry: " + aBundleEntries[i]);
+				}
 			}
 		}
 		return mResources;
@@ -1404,6 +1412,10 @@ sap.ui.define([
 	 * @since 1.0.0
 	 */
 	FHIRModel.prototype.sendPostRequest = function(sPath, oPayload, mParameters) {
+		var bBundleType = oPayload && oPayload.type && (oPayload.type == "batch" || oPayload.type == "transaction") ? true : false;
+		if (bBundleType) {
+			mParameters.forceDirectCall = true;
+		}
 		return this.loadData(sPath, mParameters, HTTPMethod.POST, oPayload);
 	};
 

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -775,4 +775,36 @@ sap.ui.define([
 		this.oFhirModel.submitChanges("bundle", undefined, fnErrorCallback);
 	});
 
+	QUnit.test("Send Batch/Transaction via POST request", function (assert) {
+		var done = assert.async();
+		this.oFhirModel.setProperty("/Patient/a2522", undefined);
+		var mParameters = {
+			headers: { "Accept": "application/json" },
+			success: function (oData) {
+				assert.deepEqual(oData.entry[0].resource, this.oFhirModel.getProperty("/Patient/a2522"));
+				assert.deepEqual(oData.entry[1].resource.total, Object.keys(this.oFhirModel.getProperty("/Coverage")).length);
+				done()
+			}.bind(this)
+		};
+		this.oFhirModel.sendPostRequest("", {
+			"id": "7ff09ab5-6af1-4349-bb19-7fccfd62850d",
+			"type": "batch",
+			"resourceType": "Bundle",
+			"entry": [
+				{
+					"request": {
+						"method": "GET",
+						"url": "Patient/a2522"
+					}
+				},
+				{
+					"request": {
+						"method": "GET",
+						"url": "Coverage"
+					}
+				}
+			]
+		}, mParameters);
+	});
+
 });

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -783,7 +783,7 @@ sap.ui.define([
 			success: function (oData) {
 				assert.deepEqual(oData.entry[0].resource, this.oFhirModel.getProperty("/Patient/a2522"));
 				assert.deepEqual(oData.entry[1].resource.total, Object.keys(this.oFhirModel.getProperty("/Coverage")).length);
-				done()
+				done();
 			}.bind(this)
 		};
 		this.oFhirModel.sendPostRequest("", {


### PR DESCRIPTION
This PR contains the fix  for sending  batch or transaction requests via sendPostRequestMethod of the fhir model and ensures proper parsing of response.
In case one of the requests in a bundle is a search call then the bundle response will have one entry which is of type bundle.  
**Sample Request**
`{"id":"7ff09ab5-6af1-4349-bb19-7fccfd62850d","type":"batch","resourceType":"Bundle","entry":[{"request":{"method":"GET","url":"Patient/a2522"}},{"request":{"method":"GET","url":"Coverage"}}]}`
**Response**
`{"resourceType":"Bundle","id":"f12caf0b-ce6d-4606-85d1-17ee5729a5ca","type":"batch-response","entry":[{"resource":{"resourceType":"Patient"},"response":{"status":"200 OK"}},{"resource":{"resourceType":"Bundle","id":"f57cc024-2d6c-4df2-aa3f-2ecf0e3d9c6c","meta":{"lastUpdated":"2021-04-22T19:59:23.434+00:00"},"type":"searchset","total":1,"entry":[{"fullUrl":"http://localhost:8080/fhir/R4/Coverage/a7854","resource":{"resourceType":"Coverage"},"response":{"status":"200 OK"}}]},"response":{"status":"200 OK"}}]}`

