### PR TITLE
fix: operator concatenation in _filter

### DIFF
--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -464,7 +464,7 @@ sap.ui.define([
 					if (!mParameters._filter) {
 						mParameters._filter = "";
 					}
-					this._complexFilterBuilder(oFilter, mParameters, undefined);
+					this._complexFilterBuilder(oFilter, mParameters);
 				} else if (oFilter._bMultiFilter && iLvl <= iSupportedFilterDepth) {
 					this.filterBuilder(oFilter.aFilters, mParameters, iSupportedFilterDepth, bIsValueSet, iLvl + 1, oFilter._bMultiFilter, oFilter.bAnd);
 				} else if (iLvl > iSupportedFilterDepth) {
@@ -519,22 +519,24 @@ sap.ui.define([
 	 *
 	 * @param {sap.ui.model.Filter} oFilter The filter which should be added to the parameters
 	 * @param {object} mParameters The parameters which should be passed to the request
-	 * @param {string} [sLogicalConnection] if the list of filters needs to be combined either with AND or OR
 	 * @private
 	 * @since 2.1.0
 	 */
-	FHIRUtils._complexFilterBuilder = function (oFilter, mParameters, sLogicalConnection) {
-		var sLogicalConnection1;
+	FHIRUtils._complexFilterBuilder = function (oFilter, mParameters) {
+		var sLogicalConnection;
 		if (oFilter instanceof Filter) {
 			if (oFilter._bMultiFilter) {
 				// recursive
-				sLogicalConnection1 = oFilter.bAnd && oFilter.bAnd == true ? "and" : "or";
+				sLogicalConnection = oFilter.bAnd && oFilter.bAnd == true ? "and" : "or";
 				if (oFilter.aFilters) {
 					mParameters._filter = mParameters._filter + "( ";
 					// for the first filter the logical connection shouldnt be appended
-					this._complexFilterBuilder(oFilter.aFilters[0], mParameters, undefined);
+					this._complexFilterBuilder(oFilter.aFilters[0], mParameters);
 					for (var i = 1; i < oFilter.aFilters.length; i++) {
-						this._complexFilterBuilder(oFilter.aFilters[i], mParameters, sLogicalConnection1);
+						if (sLogicalConnection) {
+							mParameters._filter = mParameters._filter + " " + sLogicalConnection + " ";
+						}
+						this._complexFilterBuilder(oFilter.aFilters[i], mParameters);
 					}
 					mParameters._filter = mParameters._filter + " )";
 				}
@@ -552,11 +554,7 @@ sap.ui.define([
 				} else {
 					sFilter = sPath + " " + sFilterOperator + " " + oValue1;
 				}
-				if (sLogicalConnection) {
-					mParameters._filter = mParameters._filter + " " + sLogicalConnection + " " + sFilter;
-				} else {
-					mParameters._filter = mParameters._filter + sFilter;
-				}
+				mParameters._filter = mParameters._filter + sFilter;
 			}
 		}
 	};

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1279,8 +1279,8 @@ sap.ui.define([
 		// multivalued filter
 		var oNameFilter1 = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger", valueType: FHIRFilterType.string });
 		var oNameFilter2 = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Habibi", valueType: FHIRFilterType.string });
-		var oCombinedFilter = new sap.ui.model.Filter([oNameFilter1, oNameFilter2], false);
-		aFilters = [oCombinedFilter];
+		var oNameCombinedFilter = new sap.ui.model.Filter([oNameFilter1, oNameFilter2], false);
+		aFilters = [oNameCombinedFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
@@ -1288,11 +1288,20 @@ sap.ui.define([
 
 		// multivalued filter with different value type
 		var oGenderFilter = new FHIRFilter({ path: "gender", operator: FilterOperator.EQ, value1: "male" });
-		var oCombinedFilter1 = new sap.ui.model.Filter([oCombinedFilter, oGenderFilter], true);
-		aFilters = [oCombinedFilter1];
+		var oCombinedFilter = new sap.ui.model.Filter([oNameCombinedFilter, oGenderFilter], true);
+		aFilters = [oCombinedFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq male )", "The _filter parameter object is the same");
+
+		// chain of multileveled filters with `and` operator to be concatenated
+		var oGenderFilter1 = new FHIRFilter({ path: "gender", operator: FilterOperator.EQ, value1: "other" });
+		var oGenderCombinedFilter = new sap.ui.model.Filter([oGenderFilter, oGenderFilter1], false);
+		oCombinedFilter = new sap.ui.model.Filter([oNameCombinedFilter, oGenderCombinedFilter], true);
+		aFilters = [oCombinedFilter];
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and ( gender eq male or gender eq other ) )", "The _filter parameter for multilevel filter values is the formed with the correct operator");
 
 		// filter with BT operator
 		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });


### PR DESCRIPTION
Operator concatenation wasnot happening at root level when array of filters wherein each filter is again another chain
Model was forming filter like this without the logical connection for chained filters 
`_filter=( ( DRG eq "I47C" or DRG eq "test" )( patientLastName eq "esk" or patientLastName eq "we" ) )`

<img width="1408" alt="Screenshot 2021-04-30 at 8 11 59 PM" src="https://user-images.githubusercontent.com/59359754/116847690-b0271800-ac08-11eb-9ae0-f73ad1278695.png">
