### PR TITLE
fix: pagination calls when the service url is relative

### DIFF
--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -174,8 +174,10 @@ sap.ui.define([
 				this._submitRequest("/ValueSet/$expand", mParameters, fnSuccessValueSet);
 			} else if (!this.aSortersCache && !this.aFilterCache && this.sNextLink && iLength > this.iLastLength) {
 				this.iLastLength += this.iLength;
-				// if secure search is enabled convert the next link so that the subsequent calls are handled appropriately
-				if (this.oModel.isSecureSearchModeEnabled() && this.sNextLink && this.sNextLink.indexOf("?") > -1) {
+				// the direct next links will not be used by default to send the request
+				// instead its converted into the necessary parameters and path before sending
+				// this is to address the if the service url is relative
+				if (this.sNextLink && this.sNextLink.indexOf("?") > -1) {
 					var sQueryParams = this.sNextLink.substring(this.sNextLink.indexOf("?") + 1, this.sNextLink.length);
 					var aParameter = sQueryParams ? sQueryParams.split("&") : [];
 					var aKeyValue;

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -342,7 +342,7 @@ sap.ui.define([
 				bFound = true;
 			}
 		});
-		assert.strictEqual(bFound, true, "The request of the listbinding with next link id formed based on the resource path");
+		assert.strictEqual(bFound, true, "The request of the listbinding with next link is formed based on the resource path");
 	});
 
 	QUnit.test("Context binding after _loadcontext change event has to be fired", function(assert) {

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -333,16 +333,16 @@ sap.ui.define([
 	});
 
 	QUnit.test("Call next link, which has no query params, and check that it is directly call", function(assert) {
-		this.oListBinding9.sNextLink = "https://example.com/fhir/abc?_getpages=1263645";
+		this.oListBinding9.sNextLink = "https://example.com/fhir/DummyResource?_getpages=1263645";
 		this.oListBinding9.iLastLength = 10;
 		this.oListBinding9.getContexts(0,20);
 		var bFound = false;
 		this.oFhirModel1.oRequestor._aPendingRequestHandles.forEach(function(oEntry, i) {
-			if (oEntry.getUrl().endsWith("abc?_getpages=1263645")){
+			if (oEntry.getUrl().endsWith("DummyResource?_count=10&_getpages=1263645&_total=accurate&_format=json")){
 				bFound = true;
 			}
 		});
-		assert.strictEqual(bFound, true, "The request of the listbinding with next link without params was found");
+		assert.strictEqual(bFound, true, "The request of the listbinding with next link id formed based on the resource path");
 	});
 
 	QUnit.test("Context binding after _loadcontext change event has to be fired", function(assert) {
@@ -1406,6 +1406,25 @@ sap.ui.define([
 			}
 		});
 		assert.strictEqual(bFound, true, "The request of the listbinding with next link with RESTful search is triggered correctly");
+	});
+
+	QUnit.test("Test pagination when the service url is relative and next links is absolute", function (assert) {
+		var oFhirModel = createModel();
+		var oListBinding = oFhirModel.bindList("/Practitioner");
+		oListBinding.sNextLink = "https://example.com/fhir/Practitioner?_count=10&_skip=5";
+		oListBinding.iLastLength = 10;
+		// manually set the service url to a relative url
+		// in an ideal scenario the service url is absolute but while integrating with a middleware (nginx server)
+		// the url can be relative
+		oFhirModel.oRequestor._sServiceUrl = "/../fhir";
+		oListBinding.getContexts(0, 20);
+		var bFound = false;
+		oFhirModel.oRequestor._aPendingRequestHandles.forEach(function (oEntry, i) {
+			if (oEntry.getUrl().endsWith("Practitioner?_count=10&_skip=5&_format=json")) {
+				bFound = true;
+			}
+		});
+		assert.strictEqual(bFound, true, "The request of the listbinding with next link is triggered correctly");
 	});
 
 });


### PR DESCRIPTION
Earlier the next links where getting triggered by default to fetch the next data. However if the service url is relative and the next links were complete url then the binding contexts is throwing error. The aim of the pr is to ensure no matter what the next links are transformed into the resource path and sent accordingly

<img width="1372" alt="Screenshot 2021-05-12 at 10 01 47 PM" src="https://user-images.githubusercontent.com/59359754/118131762-8e097300-b41c-11eb-8c1e-25f80b5e33ba.png">
