### PR TITLE
fix: support combined filters 

### DIFF
--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -492,11 +492,12 @@ sap.ui.define([
 			 * Filters the actual list binding depending on the given <code>aFilters</code>
 			 *
 			 * @param {sap.ui.model.Filter[]} [aFilters] The filters defined for the list binding
+			 * @param {sap.ui.model.FilterType} sFilterType Type of the filter which should be adjusted, if it is not given, the standard behaviour applies
 			 * @public
 			 * @since 1.0.0
 			 */
-	FHIRListBinding.prototype.filter = function(aFilters) {
-		FHIRUtils.filter(aFilters, this);
+	FHIRListBinding.prototype.filter = function (aFilters, sFilterType) {
+		FHIRUtils.filter(aFilters, this, sFilterType);
 	};
 
 	/**

--- a/src/sap/fhir/model/r4/FHIRTreeBinding.js
+++ b/src/sap/fhir/model/r4/FHIRTreeBinding.js
@@ -628,11 +628,12 @@ sap.ui.define([
 	 * Filters the actual list binding depending on the given <code>aFilters</code>
 	 *
 	 * @param {sap.ui.model.Filter[]} [aFilters] The filters defined for the list binding
+	 * @param {sap.ui.model.FilterType} sFilterType Type of the filter which should be adjusted, if it is not given, the standard behaviour applies
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRTreeBinding.prototype.filter = function(aFilters) {
-		FHIRUtils.filter(aFilters, this);
+	FHIRTreeBinding.prototype.filter = function (aFilters, sFilterType) {
+		FHIRUtils.filter(aFilters, this, sFilterType);
 	};
 
 	/**

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -11,8 +11,10 @@ sap.ui.define([
 	"sap/base/util/merge",
 	"sap/base/util/deepEqual",
 	"sap/ui/model/Filter",
-	"sap/ui/model/Sorter"
-], function (FHIRFilterOperatorUtils, FHIRFilterOperator, FHIRFilterComplexOperator, ChangeReason, merge, deepEqual, Filter, Sorter) {
+	"sap/ui/model/Sorter",
+	"sap/ui/model/FilterProcessor",
+	"sap/ui/model/FilterType"
+], function (FHIRFilterOperatorUtils, FHIRFilterOperator, FHIRFilterComplexOperator, ChangeReason, merge, deepEqual, Filter, Sorter, FilterProcessor, FilterType) {
 
 	"use strict";
 
@@ -564,16 +566,33 @@ sap.ui.define([
 	 *
 	 * @param {sap.ui.model.Filter | sap.ui.model.Filter[]} [aFilters] The filters defined for the list binding (can be either a filter or an array of filters)
 	 * @param {sap.fhir.model.r4.FHIRListBinding | sap.fhir.model.r4.FHIRTreeBinding} oBinding The binding which triggered the filter
+	 * @param {sap.ui.model.FilterType} sFilterType Type of the filter which should be adjusted, if it is not given, the standard behaviour applies
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRUtils.filter = function (aFilters, oBinding) {
+	FHIRUtils.filter = function (aFilters, oBinding, sFilterType) {
 		if (!aFilters) {
 			aFilters = [];
 		}
 		if (aFilters instanceof Filter) {
 			aFilters = [aFilters];
 		}
+
+		if (sFilterType == FilterType.Application) {
+			oBinding.aApplicationFilters = aFilters;
+		} else {
+			oBinding.aFilters = aFilters;
+		}
+
+		if (!aFilters || !Array.isArray(aFilters) || aFilters.length == 0) {
+			oBinding.aFilters = [];
+		}
+		//if no application-filters are present, or they are not in array form/empty array, init the filters with []
+		if (!oBinding.aApplicationFilters || !Array.isArray(oBinding.aApplicationFilters) || oBinding.aApplicationFilters.length === 0) {
+			oBinding.aApplicationFilters = [];
+		}
+		oBinding.oCombinedFilter = FilterProcessor.combineFilters(oBinding.aFilters, oBinding.aApplicationFilters);
+
 		if (oBinding.bPendingRequest) {
 			var fnQueryLastFilters = function () {
 				if (!oBinding.bPendingRequest) {

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -583,10 +583,6 @@ sap.ui.define([
 		} else {
 			oBinding.aFilters = aFilters;
 		}
-
-		if (!aFilters || !Array.isArray(aFilters) || aFilters.length == 0) {
-			oBinding.aFilters = [];
-		}
 		//if no application-filters are present, or they are not in array form/empty array, init the filters with []
 		if (!oBinding.aApplicationFilters || !Array.isArray(oBinding.aApplicationFilters) || oBinding.aApplicationFilters.length === 0) {
 			oBinding.aApplicationFilters = [];
@@ -608,7 +604,6 @@ sap.ui.define([
 			}
 			oBinding.aFilterCache = aFilters;
 		} else {
-			oBinding.aFilters = aFilters;
 			oBinding.refresh(ChangeReason.Filter);
 		}
 	};

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1427,4 +1427,18 @@ sap.ui.define([
 		assert.strictEqual(bFound, true, "The request of the listbinding with next link is triggered correctly");
 	});
 
+	QUnit.test("Test combined filters", function (assert) {
+		var oFhirModel = createModel({ filtering: { complex: true } });
+		var oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger", valueType: FHIRFilterType.string });
+		var aFilters = [oNameFilter];
+		var oListBinding = oFhirModel.bindList("/Patient");
+		oListBinding.filter(oNameFilter, sap.ui.model.FilterType.Application);
+		assert.deepEqual(oListBinding.aApplicationFilters, aFilters, "List Binding Application Filters are populated correctly if the filter type is application");
+
+		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });
+		aFilters.push(oBirthDateFilter);
+		oListBinding.filter(aFilters, sap.ui.model.FilterType.Application);
+		assert.deepEqual(oListBinding.oCombinedFilter.bAnd, true, "Combined filters are formed correctly with bAnd as true");
+	});
+
 });


### PR DESCRIPTION
initialise the combined filters property  by using the ui5 FilterProcessor.combineFilter to get the combined filter. this will merge filters  with bAnd property to be true. Similar to oData implementation https://github.com/SAP/openui5/blob/master/src/sap.ui.core/src/sap/ui/model/odata/ODataListBinding.js#L856
 This property is necessary for mdc based filters to work as expected
https://github.com/SAP/openui5/blob/master/src/sap.ui.mdc/src/sap/ui/mdc/field/FieldValueHelpTableWrapperBase.js#L517
List Binding getFilterInfo Default Implemantation
https://github.com/SAP/openui5/blob/master/src/sap.ui.core/src/sap/ui/model/ListBinding.js#L428

