### PR TITLE
fix: complex filter query

### DIFF
--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -225,14 +225,14 @@ sap.ui.define([
 	 * @since 2.1.0
 	 */
 	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, vValue) {
-		var isStringFilterType = sFilterValue && sFilterValue === FHIRFilterType.string ? true : false;
 		var sValue;
-		if (isStringFilterType) {
-			// special handling for string parameter as per fhir
-			// given eq "peter"
+		// special handling for string parameter as per fhir
+		// given eq "peter"
+		if (sFilterValue && sFilterValue === FHIRFilterType.string) {
 			sValue = "\"" + vValue + "\"";
-		} else if (vValue instanceof Date) {
-			sValue = vValue.toISOString();
+		} else if (typeof vValue === "string" && isNaN(new Date(vValue).getTime())) {
+			// incase of date as string it shouldnt be encoded
+			sValue = "\"" + vValue + "\"";
 		} else {
 			sValue = vValue;
 		}

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1292,7 +1292,7 @@ sap.ui.define([
 		aFilters = [oCombinedFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
-		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq male )", "The _filter parameter object is the same");
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and gender eq \"male\" )", "The _filter parameter object is the same");
 
 		// chain of multileveled filters with `and` operator to be concatenated
 		var oGenderFilter1 = new FHIRFilter({ path: "gender", operator: FilterOperator.EQ, value1: "other" });
@@ -1301,7 +1301,7 @@ sap.ui.define([
 		aFilters = [oCombinedFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
-		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and ( gender eq male or gender eq other ) )", "The _filter parameter for multilevel filter values is the formed with the correct operator");
+		assert.deepEqual(mParameters.urlParameters["_filter"], "( ( name eq \"Ruediger\" or name eq \"Habibi\" ) and ( gender eq \"male\" or gender eq \"other\" ) )", "The _filter parameter for multilevel filter values is the formed with the correct operator");
 
 		// filter with BT operator
 		var oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FilterOperator.BT, value1: "1965-03-23", value2: "1985-04-14" });
@@ -1321,14 +1321,13 @@ sap.ui.define([
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
 		assert.deepEqual(mParameters.urlParameters["_filter"], "( name sw \"Ra\" and name ew \"er\" )", "The _filter parameter for StartsWith and EndsWith operator is the formed correctly");
 
-		var oBirthDate = new Date(Date.UTC(2014, 2, 1, 23, 0, 0));
-		var sBirthDateISOString = "2014-03-01T23:00:00.000Z";
-		oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FHIRFilterOperator.GT, value1: oBirthDate });
+		var sBirthDate = "2014-03-01";
+		oBirthDateFilter = new FHIRFilter({ path: "birthdate", operator: FHIRFilterOperator.GT, value1: sBirthDate });
 		aFilters = [oBirthDateFilter];
 		oListBinding.filter(aFilters);
 		mParameters = oListBinding._buildParameters();
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
-		var sFilterParams = "birthdate gt " + sBirthDateISOString;
+		var sFilterParams = "birthdate gt " + sBirthDate;
 		assert.deepEqual(mParameters.urlParameters["_filter"], sFilterParams, "The _filter parameter for instance of type date is the formed correctly");
 	});
 

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1329,6 +1329,16 @@ sap.ui.define([
 		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
 		var sFilterParams = "birthdate gt " + sBirthDate;
 		assert.deepEqual(mParameters.urlParameters["_filter"], sFilterParams, "The _filter parameter for instance of type date is the formed correctly");
+
+		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Ruediger" });
+		aFilters = [oNameFilter];
+		oListBinding = oFhirModel.bindList("/Patient");
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Ruediger\"", "The _filter parameter object is the same even if the value type of string is not present");
+		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Ruediger%22") > -1, true, "The url is encoded for _filter parameter");
+
 	});
 
 	QUnit.test("RESTful search tests", function (assert) {


### PR DESCRIPTION
In case of mdc controls the filter object is generated by ui5 and hence the `valuetype` for string is not available to determine if it needs to be enclosed in quotes. 
The purpose of this PR is
1. to  identify string type based on js types and enclose it in quotes. if a valid date is given in string it wont be enclosed. 
2. to remove the conversion to iso string as if the type of the resource is not date time this would lead to incorrect filter results. For.eg. birthDate is of type date. 
This is a short term solution to handle dates and timezones(application will have the responsiblity to send it appropriately). 
Both of these are shorterm solutions
The long term solution is to determine the type of a search parameter based on the metadata
The long term solution of having Fhir date types and handling it at the model layer will be done in a later stage