### PR TITLE
fix: better handling of strings with ws and numbers

### DIFF
--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -226,18 +226,38 @@ sap.ui.define([
 	 */
 	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, vValue) {
 		var sValue;
-		// special handling for string parameter as per fhir
-		// given eq "peter"
-		var sRegex = "[ \r\n\t\S]+";
-		if (sFilterValue && sFilterValue === FHIRFilterType.string) {
-			sValue = "\"" + vValue + "\"";
-		} else if (typeof vValue === "string" && (vValue.match(sRegex) != null || isNaN(new Date(vValue).getTime()))) {
-			// incase of date as string it shouldnt be encoded
+		if (this.canBeEncoded(sFilterValue, vValue)) {
 			sValue = "\"" + vValue + "\"";
 		} else {
 			sValue = vValue;
 		}
 		return sValue;
+	};
+
+	/**
+	 * Determines if the value should be encoded or not
+	 *
+	 * @param {string} sFilterValue The value type of a filter object
+	 * @param {any} vValue The value of a filter object
+	 * @returns {boolean} true if the value needs to be encoded
+	 * @private
+	 * @since 2.2.7
+	 */
+	FHIRFilterOperatorUtils.canBeEncoded = function (sFilterValue, vValue) {
+		var sRegex = "[ \r\n\t\S]+";
+		return (sFilterValue && sFilterValue === FHIRFilterType.string) || (typeof vValue === "string" && (vValue.match(sRegex) != null || this.isValidDate(vValue)));
+	};
+
+	/**
+	 * Determines if the value is valid date object
+	 *
+	 * @param {any} vValue The value of a filter object
+	 * @returns {boolean} true if the value is not valid date
+	 * @private
+	 * @since 2.2.7
+	 */
+	FHIRFilterOperatorUtils.isValidDate = function (vValue) {
+		return isNaN(new Date(vValue).getTime());
 	};
 
 	return FHIRFilterOperatorUtils;

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -218,15 +218,15 @@ sap.ui.define([
 	/**
 	 * Parses the JS filter value to a FHIR filter value
 	 *
-	 * @param {string} sFilterValue The value type of a filter object
+	 * @param {string} sFilterType The value type of a filter object
 	 * @param {any} vValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
 	 * @public
 	 * @since 2.1.0
 	 */
-	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterValue, vValue) {
+	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterType, vValue) {
 		var sValue;
-		if (this.canBeEncoded(sFilterValue, vValue)) {
+		if (this.isFilterValueEncodable(sFilterType, vValue)) {
 			sValue = "\"" + vValue + "\"";
 		} else {
 			sValue = vValue;
@@ -237,19 +237,19 @@ sap.ui.define([
 	/**
 	 * Determines if the value should be encoded or not
 	 *
-	 * @param {string} sFilterValue The value type of a filter object
+	 * @param {string} sFilterType The value type of a filter object
 	 * @param {any} vValue The value of a filter object
 	 * @returns {boolean} true if the value needs to be encoded
 	 * @private
 	 * @since 2.2.7
 	 */
-	FHIRFilterOperatorUtils.canBeEncoded = function (sFilterValue, vValue) {
+	FHIRFilterOperatorUtils.isFilterValueEncodable = function (sFilterType, vValue) {
 		var sRegex = "[ \r\n\t\S]+";
-		return (sFilterValue && sFilterValue === FHIRFilterType.string) || (typeof vValue === "string" && (vValue.match(sRegex) != null || this.isValidDate(vValue)));
+		return (sFilterType && sFilterType === FHIRFilterType.string) || (typeof vValue === "string" && (vValue.match(sRegex) != null || this.isValidDate(vValue)));
 	};
 
 	/**
-	 * Determines if the value is valid date object
+	 * Determines if the given vValue can be parsed to a valid date object
 	 *
 	 * @param {any} vValue The value of a filter object
 	 * @returns {boolean} true if the value is not valid date

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -228,9 +228,10 @@ sap.ui.define([
 		var sValue;
 		// special handling for string parameter as per fhir
 		// given eq "peter"
+		var sRegex = "[ \r\n\t\S]+";
 		if (sFilterValue && sFilterValue === FHIRFilterType.string) {
 			sValue = "\"" + vValue + "\"";
-		} else if (typeof vValue === "string" && isNaN(new Date(vValue).getTime())) {
+		} else if (typeof vValue === "string" && (vValue.match(sRegex) != null || isNaN(new Date(vValue).getTime()))) {
 			// incase of date as string it shouldnt be encoded
 			sValue = "\"" + vValue + "\"";
 		} else {

--- a/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
+++ b/src/sap/fhir/model/r4/FHIRFilterOperatorUtils.js
@@ -219,17 +219,17 @@ sap.ui.define([
 	 * Parses the JS filter value to a FHIR filter value
 	 *
 	 * @param {string} sFilterType The value type of a filter object
-	 * @param {any} vValue The value of a filter object
+	 * @param {any} vFilterValue The value of a filter object
 	 * @returns {string} Formatted FHIR filter value
 	 * @public
 	 * @since 2.1.0
 	 */
-	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterType, vValue) {
+	FHIRFilterOperatorUtils.getFilterValueForComplexFilter = function (sFilterType, vFilterValue) {
 		var sValue;
-		if (this.isFilterValueEncodable(sFilterType, vValue)) {
-			sValue = "\"" + vValue + "\"";
+		if (this.isFilterValueEncodable(sFilterType, vFilterValue)) {
+			sValue = "\"" + vFilterValue + "\"";
 		} else {
-			sValue = vValue;
+			sValue = vFilterValue;
 		}
 		return sValue;
 	};
@@ -238,26 +238,26 @@ sap.ui.define([
 	 * Determines if the value should be encoded or not
 	 *
 	 * @param {string} sFilterType The value type of a filter object
-	 * @param {any} vValue The value of a filter object
+	 * @param {any} vFilterValue The value of a filter object
 	 * @returns {boolean} true if the value needs to be encoded
 	 * @private
 	 * @since 2.2.7
 	 */
-	FHIRFilterOperatorUtils.isFilterValueEncodable = function (sFilterType, vValue) {
+	FHIRFilterOperatorUtils.isFilterValueEncodable = function (sFilterType, vFilterValue) {
 		var sRegex = "[ \r\n\t\S]+";
-		return (sFilterType && sFilterType === FHIRFilterType.string) || (typeof vValue === "string" && (vValue.match(sRegex) != null || this.isValidDate(vValue)));
+		return (sFilterType && sFilterType === FHIRFilterType.string) || (typeof vFilterValue === "string" && (vFilterValue.match(sRegex) != null || this.isValidDate(vFilterValue)));
 	};
 
 	/**
 	 * Determines if the given vValue can be parsed to a valid date object
 	 *
-	 * @param {any} vValue The value of a filter object
+	 * @param {any} vFilterValue The value of a filter object
 	 * @returns {boolean} true if the value is not valid date
 	 * @private
 	 * @since 2.2.7
 	 */
-	FHIRFilterOperatorUtils.isValidDate = function (vValue) {
-		return isNaN(new Date(vValue).getTime());
+	FHIRFilterOperatorUtils.isValidDate = function (vFilterValue) {
+		return isNaN(new Date(vFilterValue).getTime());
 	};
 
 	return FHIRFilterOperatorUtils;

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1357,6 +1357,15 @@ sap.ui.define([
 		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Cardi abc\"", "The _filter parameter object is the same even if the value type of string is not present");
 		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Cardi%20abc%22") > -1, true, "The url is encoded for _filter parameter");
 
+		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Cardi1" });
+		aFilters = [oNameFilter];
+		oListBinding = oFhirModel.bindList("/Patient");
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Cardi1\"", "The _filter parameter object is the same even if the value type of string is not present");
+		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Cardi1%22") > -1, true, "The url is encoded for _filter parameter");
+
 	});
 
 	QUnit.test("RESTful search tests", function (assert) {

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1339,6 +1339,24 @@ sap.ui.define([
 		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Ruediger\"", "The _filter parameter object is the same even if the value type of string is not present");
 		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Ruediger%22") > -1, true, "The url is encoded for _filter parameter");
 
+		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Cardi 1" });
+		aFilters = [oNameFilter];
+		oListBinding = oFhirModel.bindList("/Patient");
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Cardi 1\"", "The _filter parameter object is the same even if the value type of string is not present");
+		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Cardi%201%22") > -1, true, "The url is encoded for _filter parameter");
+
+		oNameFilter = new FHIRFilter({ path: "name", operator: FilterOperator.EQ, value1: "Cardi abc" });
+		aFilters = [oNameFilter];
+		oListBinding = oFhirModel.bindList("/Patient");
+		oListBinding.filter(aFilters);
+		mParameters = oListBinding._buildParameters();
+		oRequestHandle = oFhirModel.loadData("/Patient", mParameters);
+		assert.deepEqual(mParameters.urlParameters["_filter"], "name eq \"Cardi abc\"", "The _filter parameter object is the same even if the value type of string is not present");
+		assert.strictEqual(oRequestHandle.getUrl().indexOf("name%20eq%20%22Cardi%20abc%22") > -1, true, "The url is encoded for _filter parameter");
+
 	});
 
 	QUnit.test("RESTful search tests", function (assert) {


### PR DESCRIPTION
when a string contains whitespace with numbers the date object validation is giving a proper date instance leading to miss of encoding the strings in quote. This pr would fix that by validating against regex mentioned in fhir  before encoding it in quotes
<img width="1373" alt="Screenshot 2021-06-08 at 9 47 11 PM" src="https://user-images.githubusercontent.com/59359754/121221423-2ae7f080-c8a3-11eb-8cd6-15ffb6c62602.png">

https://www.hl7.org/fhir/datatypes.html#string
