### PR TITLE
chore: change safeload to load

### DIFF
--- a/scripts/build/replaceCopyright.js
+++ b/scripts/build/replaceCopyright.js
@@ -5,7 +5,7 @@ const yamlPath = "ui5.yaml";
 
 function getDefaultCopyRight() {
     const content = replaceCurrentYear(fs.readFileSync(yamlPath, 'utf8'));
-    const yamlContent = yaml.safeLoad(content);
+    const yamlContent = yaml.load(content);
     return yamlContent.metadata.copyright;
 }
 


### PR DESCRIPTION
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.