### PR TITLE
feat: Enable the support of groupId in remove calls

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1492,16 +1492,17 @@ sap.ui.define([
 	 *
 	 * @param {string[]} aResources the resources which shall be deleted, e.g. ["/Patient/123", "/Organization/XYZ"]
 	 * @param {function} [fnPreProcess] to preprocess the objects of the given aResources
+	 * @param {string} [sGroupId] The group where the resource should belongs to
 	 * @public
 	 * @since 1.0.0
 	 */
-	FHIRModel.prototype.remove = function(aResources, fnPreProcess){
-		for (var i = 0; i < aResources.length; i++){
+	FHIRModel.prototype.remove = function (aResources, fnPreProcess, sGroupId) {
+		for (var i = 0; i < aResources.length; i++) {
 			var sResourcePath = fnPreProcess ? fnPreProcess(aResources[i]) : aResources[i];
 			var oBindingInfo = this.getBindingInfo(sResourcePath);
 			var aResPath = oBindingInfo.getResourcePathArray();
 			var oRequestInfo = this._getProperty(this.mChangedResources, aResPath);
-			if (oRequestInfo && oRequestInfo.method == HTTPMethod.POST){
+			if (oRequestInfo && oRequestInfo.method == HTTPMethod.POST) {
 				this._setProperty(this.oData, FHIRUtils.deepClone(aResPath));
 				this._setProperty(this.mResourceGroupId, FHIRUtils.deepClone(aResPath));
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath));
@@ -1509,7 +1510,11 @@ sap.ui.define([
 				this.checkUpdate(true);
 			} else {
 				oRequestInfo = this._createRequestInfo(HTTPMethod.DELETE, oBindingInfo.getResourceServerPath());
-				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath), oRequestInfo, true);
+				if (sGroupId) {
+					this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath), oRequestInfo, true, sGroupId);
+				} else {
+					this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath), oRequestInfo, true);
+				}
 			}
 		}
 	};

--- a/src/sap/fhir/model/r4/lib/FHIRRequestor.js
+++ b/src/sap/fhir/model/r4/lib/FHIRRequestor.js
@@ -151,7 +151,12 @@ sap.ui.define([
 			sETag = oBindingInfo.getETag();
 		}
 		var oFHIRBundleRequest = new FHIRBundleRequest(oBinding, sMethod, sRequestUrl, fnSuccess, fnError, sETag);
-		var oFHIRBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, oFHIRBundleRequest);
+		var oFHIRBundleEntry;
+		if (sMethod == HTTPMethod.POST || sMethod == HTTPMethod.PUT) {
+			oFHIRBundleEntry = new FHIRBundleEntry(sFullUrl, oResource, oFHIRBundleRequest);
+		} else {
+			oFHIRBundleEntry = new FHIRBundleEntry(sFullUrl, undefined, oFHIRBundleRequest);
+		}
 		return oFHIRBundleEntry;
 	};
 

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -56,6 +56,9 @@ sap.ui.define([
 					},
 					"bundle":{
 						"submit":"Batch"
+					},
+					"transaction":{
+						"submit":"Transaction"
 					}
 				},
 				"defaultQueryParameters": { "_total": "accurate" }
@@ -574,26 +577,26 @@ sap.ui.define([
 		oListBinding.getContexts();
 	});
 
-	QUnit.test("Reset of client changes when resource had groupid via context binding but in other context no groupid and got deleted", function(assert) {
+	QUnit.test("Reset of client changes when resource had groupid via context binding but in other context no groupid doesnot got deleted", function (assert) {
 		var oListBinding = this.oFhirModel.bindList("/Claim");
 		this.oFhirModel.aBindings.push(oListBinding);
 		var done = assert.async();
-		var fnAssertion = function(){
+		var fnAssertion = function () {
 			oListBinding.attachDataReceived(fnAssertion);
 			var sId = this.oFhirModel.create("Claim");
-			var oContextBinding = this.oFhirModel.bindContext("/Claim/" + sId, undefined, { groupId : "patientDetails"});
+			var oContextBinding = this.oFhirModel.bindContext("/Claim/" + sId, undefined, { groupId: "patientDetails" });
 			var oPropertyBinding = this.oFhirModel.bindProperty("created", oContextBinding.getBoundContext());
 			this.oFhirModel.aBindings.push(oContextBinding);
 			this.oFhirModel.aBindings.push(oPropertyBinding);
 			var oDate = new Date();
 			oPropertyBinding.setValue(oDate);
-			this.oFhirModel.submitChanges("patientDetails", function(aFHIRResource){
+			this.oFhirModel.submitChanges("patientDetails", function (aFHIRResource) {
 				var oFHIRResource = aFHIRResource.find(function (oResource) {
 					return oResource.resourceType === "Claim";
 				});
 				this.oFhirModel.remove(["/Claim/" + oFHIRResource.id]);
-				this.oFhirModel.submitChanges("patientDetails", function(oData){
-					assert.deepEqual(this.oFhirModel.mChangedResources["Claim"], {} , "Claim in changed resources got cleared");
+				this.oFhirModel.submitChanges("patientDetails", function (oData) {
+					assert.deepEqual(Object.keys(this.oFhirModel.mChangedResources["Claim"]).length, 1, "Claim in changed resources doesnot get cleared if its not removed using the same group with which it got created");
 					done();
 				}.bind(this));
 			}.bind(this));
@@ -805,6 +808,45 @@ sap.ui.define([
 				}
 			]
 		}, mParameters);
+	});
+
+	QUnit.test("Remove resources from a group and submit changes together", function (assert) {
+		this.oFhirModel.create("Practitioner", {
+			name: [
+				{
+					family: "ray",
+					given: ["duncan"]
+				}
+			]
+		}, "transaction");
+		this.oFhirModel.create("Practitioner", {
+			name: [
+				{
+					family: "ray",
+					given: ["charles"]
+				}
+			]
+		}, "transaction");
+		var done = assert.async();
+		var sResId;
+		var fnSuccessCallback = function (aFHIRResource) {
+			sResId = aFHIRResource[0].id;
+			this.oFhirModel.create("Practitioner", {
+				name: [
+					{
+						family: "ray",
+						given: ["melise"]
+					}
+				]
+			}, "transaction");
+			this.oFhirModel.remove(["/Practitioner/" + sResId], undefined, "transaction");
+			var mRequestHandles = this.oFhirModel.submitChanges("transaction",function(aFHIRResource){
+				done();
+			});
+			assert.deepEqual(mRequestHandles.transaction.getBundle().getBundleEntries().length, 2, "Number of bundle entries are correct after the removing resource from a particular group");
+			done();
+		}.bind(this);
+		this.oFhirModel.submitChanges("transaction", fnSuccessCallback);
 	});
 
 });


### PR DESCRIPTION
This pr enables the support of group id in remove calls so when the submit changes are triggered all the removed resources will also me part of same request rather than sending separated requests