### PR TITLE
fix(sap.fhir.model.r4.FHIRListBinding): Trigger binding updates when resource is removed or a rollback is performed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.FHIRBOT_GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: openui5fhirbot
+          GIT_AUTHOR_EMAIL: openui5-fhir@sap.com
+          GIT_COMMITTER_NAME: openui5fhirbot
+          GIT_COMMITTER_EMAIL: openui5-fhir@sap.com
         run: npx semantic-release
       - name: Generate API Documentation
         run: npm run docs

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -404,7 +404,7 @@ sap.ui.define([
 							// client changes (not yet submitted to server)
 							this.aKeys.splice(this.aKeys.indexOf(oBindingInfo.getResourceType() + "/" + sId), 1);
 						} else {
-							// if direct call(response from server after submit)
+							// server changes (response from server after submitted the removed resources directly)
 							this.aKeysServerState.splice(this.aKeysServerState.indexOf(oBindingInfo.getResourceType() + "/" + sId), 1);
 						}
 					} else if (sMethod === HTTPMethod.POST) {

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -111,12 +111,7 @@ sap.ui.define([
 				throw new Error("FHIR Server error: The \"total\" property is missing in the response for the requested FHIR resource " + this.sPath);
 			}
 			this.bDirectCallPending = false;
-			if (!this.aKeys) {
-				this.aKeys = [];
-				iStartIndex = 0;
-			} else {
-				iStartIndex = this.aKeys.length;
-			}
+			iStartIndex = this.aKeys.length;
 			if (oData.entry && oData.entry.length){
 				var oResource;
 				var oBindingInfo = this.oModel.getBindingInfo(this.sPath, this.oContext, this.bUnique);

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1520,7 +1520,7 @@ sap.ui.define([
 	};
 
 	/**
-	 * Add the resource path to the removed resources map
+	 * Adds the resource path to the removed resources map
 	 *
 	 * @param {sap.fhir.model.r4.lib.BindingInfo} oBindingInfo The binding info object
 	 * @param {string} [sResourcePath] The resource path of the removed resource

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1592,6 +1592,7 @@ sap.ui.define([
 	 * Removes a resource from the order resources map
 	 *
 	 * @param {sap.fhir.model.r4.lib.BindingInfo} oBindingInfo The binding info object
+	 * @private
 	 */
 	FHIRModel.prototype._removeFromOrderResources = function(oBindingInfo){
 		var sType = oBindingInfo.getResourceType();

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -1513,13 +1513,24 @@ sap.ui.define([
 			} else {
 				oRequestInfo = this._createRequestInfo(HTTPMethod.DELETE, oBindingInfo.getResourceServerPath());
 				this._setProperty(this.mChangedResources, FHIRUtils.deepClone(aResPath), oRequestInfo, true, sResourceGroupId && sResourceGroupId === sGroupId ? sGroupId : undefined);
-				if (!this.mRemovedResources[oBindingInfo.getResourceType()]) {
-					this.mRemovedResources[oBindingInfo.getResourceType()] = [sResourcePath.substring(1)];
-				} else {
-					this.mRemovedResources[oBindingInfo.getResourceType()].unshift(sResourcePath.substring(1));
-				}
+				this._addToRemovedResources(oBindingInfo, sResourcePath);
 				this.checkUpdate(true, this.mChangedResources, oBindingInfo, HTTPMethod.DELETE);
 			}
+		}
+	};
+
+	/**
+	 * Add the resource path to the removed resources map
+	 *
+	 * @param {sap.fhir.model.r4.lib.BindingInfo} oBindingInfo The binding info object
+	 * @param {string} [sResourcePath] The resource path of the removed resource
+	 * @private
+	 */
+	FHIRModel.prototype._addToRemovedResources = function (oBindingInfo, sResourcePath) {
+		if (!this.mRemovedResources[oBindingInfo.getResourceType()]) {
+			this.mRemovedResources[oBindingInfo.getResourceType()] = [sResourcePath.substring(1)];
+		} else {
+			this.mRemovedResources[oBindingInfo.getResourceType()].unshift(sResourcePath.substring(1));
 		}
 	};
 
@@ -1593,9 +1604,10 @@ sap.ui.define([
 	};
 
 	/**
-	 * Removes a resource from the remove resources map
+	 * Removes a resource from the removed resources map
 	 *
 	 * @param {sap.fhir.model.r4.lib.BindingInfo} oBindingInfo The binding info object
+	 * @private
 	 */
 	FHIRModel.prototype._removeFromRemovedResources = function (oBindingInfo) {
 		var sType = oBindingInfo.getResourceType();

--- a/test/data/Practitioner.json
+++ b/test/data/Practitioner.json
@@ -3,6 +3,29 @@
     "type": "transaction",
     "entry": [
         {
+            "fullUrl": "http://localhost:8080/fhir/R4/Practitioner/a4748",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "a4748",
+                "meta": {
+                    "versionId": "1",
+                    "lastUpdated": "2018-09-19T16:05:18.620+02:00"
+                },
+                "name": [
+                    {
+                        "family": "Melisa",
+                        "given": [
+                            "Ray"
+                        ]
+                    }
+                ]
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Practitioner/a4748"
+            }
+        },
+        {
             "fullUrl": "http://localhost:8080/fhir/R4/Practitioner/a2533",
             "resource": {
                 "resourceType": "Practitioner",

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -863,10 +863,12 @@ sap.ui.define([
 			this.oFhirModel.resetChanges("patientDetails");
 			assert.deepEqual(oListBinding.getContexts().length, iCurrentLength, "List shows the previously removed items if the changes are not submitted and reset changes is triggered");
 			assert.deepEqual(this.oFhirModel.mRemovedResources["Practitioner"], undefined, "Removed Resources of the model is correctly cleared during reset changes");
+			assert.deepEqual(this.oFhirModel.mRemovedResources.hasOwnProperty("Practitioner"), false, "The key doesn't exists if there are no removed resources for a particular type");
 			this.oFhirModel.remove([sResPath], undefined, "patientDetails");
 			assert.deepEqual(this.oFhirModel.mRemovedResources["Practitioner"].length, 1, "Removed Resources of the model is correctly filled");
 			this.oFhirModel.submitChanges("patientDetails", function (aFHIRResource) {
 				assert.deepEqual(this.oFhirModel.mRemovedResources["Practitioner"], undefined, "Removed Resources of the model is correctly cleared after submitting changes");
+				assert.deepEqual(this.oFhirModel.mRemovedResources.hasOwnProperty("Practitioner"), false, "The key doesn't exists if there are no removed resources for a particular type");
 				done();
 			}.bind(this));
 		}.bind(this);

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -326,10 +326,12 @@ sap.ui.define([
 		assert.strictEqual(sSubmitMode, "Transaction", "The default submit mode is defined");
 	});
 
-	QUnit.test("Removing Resources from FHIR Model", function(assert) {
+	QUnit.test("Removing Resources from FHIR Model", function (assert) {
 		var mChangedResources = JSON.parse("{\"Patient\":{\"123\":{\"url\":\"/Patient/123\",\"method\":\"DELETE\"},\"abc\":{\"url\":\"/Patient/abc\",\"method\":\"DELETE\"}}}");
+		var mRemovedResources = JSON.parse("{\"Patient\":[\"Patient/abc\",\"Patient/123\"]}");
 		this.oFhirModel1.remove(["/Patient/123", "/Patient/abc"]);
 		assert.deepEqual(mChangedResources, this.oFhirModel1.mChangedResources, "The changed resources are equal");
+		assert.deepEqual(mRemovedResources, this.oFhirModel1.mRemovedResources, "The removed resources are equal");
 	});
 
 	QUnit.test("Call next link, which has no query params, and check that it is directly call", function(assert) {


### PR DESCRIPTION
This PR is for fixing the list binding still showing the removed items if submit changes is not done immediately.
Use another array to capture the client removed resources and fill it appropriately to decide whether during reset changes the contexts needs to be recreated (for those resources which are not yet submitted but was removed using the remove operation)