### PR TITLE
fix(sap.fhir.model.r4.FHIRListBinding): Invalidate list bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "npm": ">= 5"
   },
   "devDependencies": {
-    "eslint": "^8.15.0",
+    "eslint": "^8.17.0",
     "eslint-watch": "^8.0.0",
     "js-beautify": "^1.14.3",
     "jsdoc": "^3.6.10",

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -65,7 +65,15 @@ sap.ui.define([
 			}
 			this.sId = FHIRUtils.uuidv4();
 			this._resetData();
+		},
+
+		initialize: function () {
+			// List doesn't get invalidated when context length is 0
+			// as per suggestion Server-side bindings (e.g. ODataListBinding) are expected to start with a "refresh" event
+			// overwrite the ListBindings "initialize" + fire refresh-event (although not defined in the metadata)
+			this.fireEvent("refresh", { reason: ChangeReason.Refresh });
 		}
+
 	});
 
 	/**

--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -72,6 +72,7 @@ sap.ui.define([
 			// as per suggestion Server-side bindings (e.g. ODataListBinding) are expected to start with a "refresh" event
 			// overwrite the ListBindings "initialize" + fire refresh-event (although not defined in the metadata)
 			this.fireEvent("refresh", { reason: ChangeReason.Refresh });
+			return this;
 		}
 
 	});

--- a/test/qunit/model/FHIRListBinding.integration.js
+++ b/test/qunit/model/FHIRListBinding.integration.js
@@ -8,8 +8,7 @@ sap.ui.define(["../utils/TestUtilsIntegration", "../utils/TestUtils"], function 
 	}
 
 	function createListBinding(sPath, oContext, aSorters, aFilters, mParameters) {
-		oListBinding = oModel.bindList(sPath, oContext, aSorters, aFilters, mParameters);
-		oListBinding.initialize();
+		oListBinding = oModel.bindList(sPath, oContext, aSorters, aFilters, mParameters).initialize();
 	}
 
 	function createContextBinding(sPath, oContext, mParameters) {

--- a/test/qunit/model/FHIRListBinding.integration.js
+++ b/test/qunit/model/FHIRListBinding.integration.js
@@ -8,7 +8,8 @@ sap.ui.define(["../utils/TestUtilsIntegration", "../utils/TestUtils"], function 
 	}
 
 	function createListBinding(sPath, oContext, aSorters, aFilters, mParameters) {
-		oListBinding = oModel.bindList(sPath, oContext, aSorters, aFilters, mParameters).initialize();
+		oListBinding = oModel.bindList(sPath, oContext, aSorters, aFilters, mParameters);
+		oListBinding.initialize();
 	}
 
 	function createContextBinding(sPath, oContext, mParameters) {

--- a/test/qunit/model/FHIRListBinding.integration.js
+++ b/test/qunit/model/FHIRListBinding.integration.js
@@ -59,4 +59,16 @@ sap.ui.define(["../utils/TestUtilsIntegration", "../utils/TestUtils"], function 
 	QUnit.test("check if valueset is loaded if mentioned in the structure definition field description of type 'codeableconcept'", function (assert) {
 		testValueSetLoadedCorrectly(assert, "/Coverage/a7854", "type", 1, 21);
 	});
+
+	QUnit.test("check if refresh event is triggered during list binding initialization", function (assert) {
+		createContextBinding("/Patient/a2519");
+		oListBinding = oModel.bindList("gender", oContextBinding.getBoundContext(), undefined, undefined, undefined);
+		var done = assert.async();
+		var fnChangeHandler = function (oEvent) {
+			assert.strictEqual(oEvent.mParameters.reason, "refresh");
+			done();
+		};
+		oListBinding.attachRefresh(fnChangeHandler);
+		oListBinding.initialize();
+	});
 });


### PR DESCRIPTION
As per suggestion Server-side bindings (e.g. ODataListBinding) are expected to start with a "refresh" eventListBindings "initialize" , fire refresh-event (although not defined in the metadata)