### PR TITLE
chore: upgrade node version in workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node 
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20
       - name: Install NPM dependencies
         run: npm install
       - name: Setup Java 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node 
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20
       - name: Install NPM dependencies
         run: npm install
       - name: Setup Java 
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20
       - name: Install dependencies
         run: npm install
       - name: Run Semantic Release


### PR DESCRIPTION
The  release is failing due to node version from semantic plugin
https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md
Changing the version to 20.