### PR TITLE
fix: (sap.fhir.model.r4.FHIRListBinding) with secure search and group id

### DIFF
--- a/src/sap/fhir/model/r4/FHIRListBinding.js
+++ b/src/sap/fhir/model/r4/FHIRListBinding.js
@@ -57,6 +57,7 @@ sap.ui.define([
 				throw new Error("Unsupported OperationMode: " + this.sOperationMode + ". Only sap.fhir.model.r4.OperationMode.Server is supported.");
 			}
 			this.sGroupId = mParameters && mParameters.groupId || oContext && oContext.sGroupId;
+			this.bSecureSearch = oModel.bSecureSearch;
 			this.bUnique = mParameters && mParameters.unique;
 			if (mParameters) {
 				this.bValueSetLookupInStructureDefinition = mParameters.valueSetLookupInStructureDefinition === undefined ? true : mParameters.valueSetLookupInStructureDefinition;
@@ -372,7 +373,7 @@ sap.ui.define([
 					 */
 	FHIRListBinding.prototype._loadProfile = function(fnSuccessCallbackStructureDefintion, fnLoadResources, fnSuccessCallback, mParameters, iLength) {
 		if (!this.isRelative()) {
-			this._submitRequest(this.sPath, mParameters, fnSuccessCallback);
+			this._submitRequest(this.sPath, mParameters, fnSuccessCallback, this.bSecureSearch);
 		} else if (this.oContext && this.bValueSetLookupInStructureDefinition) {
 			var oBindingInfo = this.oModel.getBindingInfo(this.sPath, this.oContext, this.bUnique);
 			var oResource = this.oModel.getProperty(oBindingInfo.getResourcePath()) || {};

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -498,6 +498,9 @@ sap.ui.define([
 				oResponse.meta.lastUpdated = mResponseHeaders["last-modified"];
 				this.oData[oResponse.resourceType][oResponse.id] = oResponse;
 			} else {
+				if (oBinding && oBinding.sGroupId) {
+					sGroupId = oBinding.sGroupId;
+				}
 				this._mapFHIRResponse(oResponse, mResponseHeaders, oBundleEntry, oBinding, sGroupId);
 			}
 

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -66,6 +66,10 @@ sap.ui.define([
 			this.oMessageModel = sap.ui.getCore().getMessageManager().getMessageModel();
 			this.oFhirModel = createModel(mParameters);
 			this.oFhirModel1 = createModel(mParameters);
+			mParameters.search = {
+				"secure": true
+			};
+			this.oFhirModel2 = createModel(mParameters);
 		},
 
 		/**
@@ -897,6 +901,23 @@ sap.ui.define([
 			}
 		};
 		oFhirModel.attachRequestCompleted(fnRequestCompleted);
+	});
+
+	QUnit.test("check contexts in listbinding after and before paging along with group id and restful search enabled", function (assert) {
+		var oListBinding = this.oFhirModel2.bindList("/Patient", undefined, undefined, undefined, { "groupId": "bundle" });
+		oListBinding.getContexts(0, 2);
+		var done1 = assert.async();
+		var fnDataReceivedCheck = function (oData) {
+			if (oListBinding.aKeys.length === 4) {
+				var aKeys = Object.keys(this.oModel.mResourceGroupId.Patient);
+				assert.deepEqual(aKeys.length, oListBinding.aKeys.length, "The keys are generated correctly");
+				assert.deepEqual(this.oModel.mResourceGroupId.Patient[aKeys[0]], "bundle", "All the keys of the listbindings are mapped to the group id correctly even though the secure search is enabled");
+				done1();
+			} else {
+				oListBinding.getContexts(0, 4);
+			}
+		};
+		oListBinding.attachDataReceived(fnDataReceivedCheck);
 	});
 
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -50,6 +50,9 @@ sap.ui.define([
 					},
 					"valueSets" : {
 						"submit" : "Batch"
+					},
+					"batch":{
+						"submit":"Batch"
 					}
 				},
 				"defaultQueryParameters": { "_total": "accurate" }
@@ -1396,6 +1399,7 @@ sap.ui.define([
 		oRequestHandle = oFhirModel.loadData("/Patient/123/$look-up");
 		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/Patient/123/$look-up?_format=json", "Any custom operation call is not converted to POST _search call");
 
+		// metadata requests
 		oRequestHandle = oFhirModel.loadData("/metadata");
 		assert.strictEqual(oRequestHandle.getUrl(), "https://example.com/fhir/metadata?_format=json", "Any metadata request call is not converted to POST _search call");
 
@@ -1449,6 +1453,19 @@ sap.ui.define([
 			}
 		});
 		assert.strictEqual(bFound, true, "The request of the listbinding with next link with RESTful search is triggered correctly");
+
+		// list binding with group id
+		oListBinding = oFhirModel.bindList("/RelatedPerson", undefined, undefined, undefined, { "groupId": "batch" });
+		oListBinding.getContexts(0, 10);
+		bFound = false;
+		oFhirModel.oRequestor._aPendingRequestHandles.forEach(function (oEntry, i) {
+			if (oEntry.getUrl().endsWith("RelatedPerson/_search")) {
+				bFound = true;
+				assert.strictEqual(oEntry.getData(), "_count=10&_format=json", "The form data of the listbinding with RESTful search is correct");
+			}
+		});
+		assert.strictEqual(bFound, true, "The request of the listbinding with RESTful search is triggered correctly even if the group id is present");
+
 	});
 
 	QUnit.test("Test pagination when the service url is relative and next links is absolute", function (assert) {


### PR DESCRIPTION
When secure search is enabled and the list binding is created with group id the resources post response is not mapped to the group id due to which the submit changes are not triggered for all those created contexts