### PR TITLE
feat: return deleted resources object from submitChanges

### DIFF
--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -694,15 +694,15 @@ sap.ui.define([
 						);
 						aPromises.push(oPromise);
 						oPromise.then(function (aFHIRResource) {
-							if (aFHIRResource.length == 0) {
+							if (removedResources.length != 0) {
 								aFHIRResource = removedResources;
 							}
 							fnSuccessCallback(aFHIRResource);
 						}).catch(function (oError) {
 							if (fnErrorCallback && oError.requestHandle) {
-								var sIds = FHIRUtils.getsIdFromOperationOutcome(oError.operationOutcomes);
-								if (oError.resources.length == 0){
-									oError.resources = FHIRUtils.filterResourcesByIds(removedResources,sIds);
+								if (removedResources.length != 0) {
+									var sIds = FHIRUtils.getsIdFromOperationOutcome(oError.operationOutcomes);
+									oError.resources = FHIRUtils.filterResourcesByIds(removedResources, sIds);
 								}
 								var mParameters = {
 									message: oError.requestHandle.getRequest().statusText,

--- a/src/sap/fhir/model/r4/FHIRModel.js
+++ b/src/sap/fhir/model/r4/FHIRModel.js
@@ -701,9 +701,8 @@ sap.ui.define([
 						}).catch(function (oError) {
 							if (fnErrorCallback && oError.requestHandle) {
 								var sIds = FHIRUtils.getsIdFromOperationOutcome(oError.operationOutcomes);
-								removedResources = removedResources.filter(obj => !sIds.includes(obj.id));
 								if (oError.resources.length == 0){
-									oError.resources = removedResources;
+									oError.resources = FHIRUtils.filterResourcesByIds(removedResources,sIds);
 								}
 								var mParameters = {
 									message: oError.requestHandle.getRequest().statusText,

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -717,6 +717,20 @@ sap.ui.define([
 		return sFullUrl;
 	};
 
+	FHIRUtils.getsIdFromOperationOutcome = function(operationOutcomes){
+		var sIds = [];
+		for (var key in operationOutcomes) {
+			if (operationOutcomes.hasOwnProperty(key)) {
+				var operationOutcome = operationOutcomes[key];
+			    var text = operationOutcome._aIssue[0].details.text;
+				var sId = text.match(/[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}/);
+				sIds.push(sId[0]);
+			}
+		}
+		return sIds;
+
+	};
+
 	return FHIRUtils;
 
 });

--- a/src/sap/fhir/model/r4/FHIRUtils.js
+++ b/src/sap/fhir/model/r4/FHIRUtils.js
@@ -731,6 +731,13 @@ sap.ui.define([
 
 	};
 
+	FHIRUtils.filterResourcesByIds = function(resources, sIds) {
+		function isIdNotIncluded(obj) {
+			return !sIds.includes(obj.id);
+		}
+		return resources.filter(isIdNotIncluded);
+	};
+
 	return FHIRUtils;
 
 });

--- a/test/localService/BundleWithDeleteSuccessAndFailureEntries.json
+++ b/test/localService/BundleWithDeleteSuccessAndFailureEntries.json
@@ -1,0 +1,43 @@
+{
+   "resourceType": "Bundle",
+   "id": "934953d3-35a3-477d-8c9e-0948a7e553ec",
+   "links": [],
+   "type": "batch-response",
+   "entry": [
+       {
+           "response": {
+               "status": "409 CONFLICT",
+               "outcome": {
+                   "issue": [
+                       {
+                           "severity": "error",
+                           "code": "conflict",
+                           "details": {
+                               "text": "Referenced resource exist 'e1692049-4bdc-4e40-abb5-4eae27ce0b8b' for resource 'RolePermission}'"
+                           },
+                           "diagnostics": "Referenced resource exist 'e1692049-4bdc-4e40-abb5-4eae27ce0b8b' for resource 'RolePermission}'"
+                       }
+                   ],
+                   "resourceType": "OperationOutcome",
+                   "meta": {
+                       "profile": [
+                           "http://hl7.org/fhir/StructureDefinition/OperationOutcome"
+                       ]
+                   }
+               }
+           }
+       },
+       {
+           "response": {
+               "status": "204 NO_CONTENT"
+           },
+           "fullUrl": "urn:uuid:cb62c497-ee6c-4c26-9721-2668f797e6c8"
+       }
+   ],
+   "total": 2,
+   "meta": {
+       "profile": [
+           "http://hl7.org/fhir/StructureDefinition/Bundle"
+       ]
+   }
+}

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -926,11 +926,10 @@ sap.ui.define([
 		var sResId = this.oFhirModel.create("RolePermission", {
 			resourceType: "RolePermission",
 			version: "1.0.0",
-			name: "PersonaRead",
-		   
+			name: "PersonaRead"
 		}, "bundle");
-		this.oFhirModel.mChangedResources={};
-        this.oFhirModel.remove(["/RolePermission/" + sResId], undefined, "bundle");
+		this.oFhirModel.mChangedResources = {};
+		this.oFhirModel.remove(["/RolePermission/" + sResId], undefined, "bundle");
 		var fnErrorCallback = function (oMessage, aFHIRResource, aOperationOutcome) {
 			assert.strictEqual(aOperationOutcome.length, 1, "Bundle error callback contains the opertion outcome of the failed entry ");
 			done();

--- a/test/qunit/model/FHIRModel.integration.js
+++ b/test/qunit/model/FHIRModel.integration.js
@@ -920,4 +920,23 @@ sap.ui.define([
 		oListBinding.attachDataReceived(fnDataReceivedCheck);
 	});
 
+	QUnit.test("Test delete containing successful entry and operation outcome", function (assert) {
+		var oJSONData = TestUtils.loadJSONFile("BundleWithDeleteSuccessAndFailureEntries");
+		var done = assert.async();
+		var sResId = this.oFhirModel.create("RolePermission", {
+			resourceType: "RolePermission",
+			version: "1.0.0",
+			name: "PersonaRead",
+		   
+		}, "bundle");
+		this.oFhirModel.mChangedResources={};
+        this.oFhirModel.remove(["/RolePermission/" + sResId], undefined, "bundle");
+		var fnErrorCallback = function (oMessage, aFHIRResource, aOperationOutcome) {
+			assert.strictEqual(aOperationOutcome.length, 1, "Bundle error callback contains the opertion outcome of the failed entry ");
+			done();
+		};
+		TestUtilsIntegration.manipulateResponse("http://localhost:8080/fhir/R4", this.oFhirModel, TestUtilsIntegration.setResponseJSON, undefined, oJSONData);
+		this.oFhirModel.submitChanges("bundle", undefined, fnErrorCallback);
+	});
+
 });

--- a/test/qunit/model/FHIRModel.unit.js
+++ b/test/qunit/model/FHIRModel.unit.js
@@ -1503,4 +1503,11 @@ sap.ui.define([
 
 	});
 
+	QUnit.test("Test getRemovedResourcesObject returning the correct value", function(assert){
+	 this.oFhirModel1.mRemovedResources = {RolePermission:["RolePermission/123"]};
+	 this.oFhirModel1.setProperty("/RolePermission/123", {id:123, description:"this is a test object", resourceType:"RolePermission"});
+	 var resources = this.oFhirModel1.getRemovedResourcesObject();
+	 assert.deepEqual(resources, [{ id: 123, description: "this is a test object", resourceType: "RolePermission" }], "Correct resources returned");
+	});
+
 });

--- a/test/qunit/model/FHIRUtils.unit.js
+++ b/test/qunit/model/FHIRUtils.unit.js
@@ -516,4 +516,28 @@ sap.ui.define(["../utils/TestUtils", "sap/fhir/model/r4/FHIRUtils"], function(Te
 		sFullUrl = FHIRUtils.generateFullUrl(TestUtils.createUri("url"), "/Patient/123", "123", "http://example.com");
 		assert.strictEqual(sFullUrl, "http://example.com/Patient/123");
 	});
+
+	QUnit.test("Test getIDsFromOperationOutcomes", function(assert) {
+		var operationOutcomes = {
+			"0": {
+				"_sResourceType": "OperationOutcome",
+				"_aIssue": [
+					{
+						"severity": "error",
+						"code": "conflict",
+						"details": {
+							"text": "Referenced resource exist '7b4abf15-8a93-4e11-8d85-96c945530d05' for resource 'RolePermission}'"
+						},
+						"diagnostics": "Referenced resource exist '7b4abf15-8a93-4e11-8d85-96c945530d05' for resource 'RolePermission}'"
+					}
+				]
+			}
+		};
+		var expectedIds = ["7b4abf15-8a93-4e11-8d85-96c945530d05"];
+
+		var actualIds = FHIRUtils.getsIdFromOperationOutcome(operationOutcomes);
+
+		assert.deepEqual(actualIds, expectedIds, "IDs extracted correctly from operationOutcomes");
+	});
+
 });

--- a/test/qunit/model/FHIRUtils.unit.js
+++ b/test/qunit/model/FHIRUtils.unit.js
@@ -540,4 +540,15 @@ sap.ui.define(["../utils/TestUtils", "sap/fhir/model/r4/FHIRUtils"], function(Te
 		assert.deepEqual(actualIds, expectedIds, "IDs extracted correctly from operationOutcomes");
 	});
 
+	QUnit.test("Test filterResourcesByIds", function(assert) {
+		var resources = [
+			{ id: "1", name: "Resource 1" },
+			{ id: "2", name: "Resource 2" },
+			{ id: "3", name: "Resource 3" }
+		];
+		var sIds = ["2"];
+		var filteredResources = FHIRUtils.filterResourcesByIds(resources, sIds);
+		assert.deepEqual(filteredResources, [ { id: "1", name: "Resource 1" },{ id: "3", name: "Resource 3" }], "Filtered resources should match expected result");
+	});
+
 });


### PR DESCRIPTION
This PR aims to enhance the handling of deleted resources during the submit changes process. Currently, when a resource is deleted, only a status code is returned from the API without providing any details regarding the deleted resource. This PR addresses this limitation by introducing improvements in two key scenarios:

1. **Handling Individual Resource Deletion:**
   - Before submitting changes, the list of deleted resources is fetched in `getRemovedResourcesObject` method in `FHIRModel.js`
   - Upon successful deletion, it is ensured that the details of the deleted resources are returned along with the response.

2. **Handling Partial Deletion:**
   - In cases where multiple resources are being deleted and only partial deletion is successful, the details of the resource(s) for which deletion was successful iS gathered through newly introduced method `getsIdFromOperationOutcome` located in `FHIRUtility.js`.
   - Only the details of the successfully deleted resource(s) are returned as part of `oError.resources`.

