### PR TITLE
chore: Using env secrets with protection and disable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
      needs: build
      name: Release
      runs-on: ubuntu-latest
+     environment: production
      permissions:
        contents: read
      steps:
@@ -61,15 +62,15 @@ jobs:
           node-version: 22
       - name: Install dependencies
         run: npm install
-      - name: Run Semantic Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.FHIRBOT_GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GIT_AUTHOR_NAME: openui5fhirbot
-          GIT_AUTHOR_EMAIL: openui5-fhir@sap.com
-          GIT_COMMITTER_NAME: openui5fhirbot
-          GIT_COMMITTER_EMAIL: openui5-fhir@sap.com
-        run: npx semantic-release
+      # - name: Run Semantic Release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.FHIRBOT_GH_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #     GIT_AUTHOR_NAME: openui5fhirbot
+      #     GIT_AUTHOR_EMAIL: openui5-fhir@sap.com
+      #     GIT_COMMITTER_NAME: openui5fhirbot
+      #     GIT_COMMITTER_EMAIL: openui5-fhir@sap.com
+      #   run: npx semantic-release
       - name: Generate API Documentation
         run: npm run docs
       - name: Deploy


### PR DESCRIPTION
Attaches the release job to a GitHub Environment so that deployment secrets (FHIRBOT_GH_TOKEN, NPM_TOKEN) are protected by required reviewers and branch restrictions instead of being available to all workflow runs.